### PR TITLE
Disabler maven wagon http pool slik det er gjort i familie-felles

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -52,4 +52,4 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn --settings .github/maven-settings.xml deploy -DskipTests=true
+        run: mvn --settings .github/maven-settings.xml deploy -DskipTests=true -Dmaven.wagon.http.pool=false


### PR DESCRIPTION
"deploy to github package"-steget feiler her, men ikke helt på samme måte som i familie-felles. Dette er et kun et forsøk - må rulles tilbake om det ikke har noen hensikt.