### PR TITLE
Funksjon for å hente behandlingsid for første utbetalingsperiode

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/Utbetalingsoppdrag.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/Utbetalingsoppdrag.kt
@@ -36,3 +36,8 @@ data class Utbetalingsperiode (
 data class Opphør (
     val opphørDatoFom: LocalDate
 )
+
+fun Utbetalingsoppdrag.behandlingsIdForFørsteUtbetalingsperiode(): String {
+
+    return utbetalingsperiode[0].behandlingId.toString()
+}


### PR DESCRIPTION
La denne inn i kontrakten da vi kommer til å bruke den mange steder. Fordelaktig at implementasjonen for å hente gjeldende behandlingsid ligger her, da sikrer vi at det er likt på tvers.