### PR TITLE
Fjern unødvendig felt, fjern unødvendig @NotNull-sjekk

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/arkivering/ArkiverDokumentRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/arkivering/ArkiverDokumentRequest.kt
@@ -2,13 +2,10 @@ package no.nav.familie.kontrakter.felles.arkivering
 
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotEmpty
-import javax.validation.constraints.NotNull
 
 data class ArkiverDokumentRequest(@field:NotBlank val fnr: String,
-                                  @field:NotNull val forsøkFerdigstill: Boolean,
+                                  val forsøkFerdigstill: Boolean,
                                   @field:NotEmpty val dokumenter: List<Dokument>,
-                                  val fagsakId: String?= null,
-                                  val journalførendeEnhet: String? = null) { //Skal ikke settes for innkommende hvis Ruting gjøres av BRUT001
-  
-    val isForsøkFerdigstill = forsøkFerdigstill
-}
+                                  val fagsakId: String? = null,
+                                  val journalførendeEnhet: String? = null) //Skal ikke settes for innkommende hvis Ruting gjøres av BRUT001
+


### PR DESCRIPTION
- En Kotlin-Boolean mappes om til en primitiv boolean, så bruk av ArkiverDokumentRequest fra Java er trygt.