### PR TITLE
Forenkle adresse

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/Adresse.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/Adresse.kt
@@ -1,9 +1,6 @@
 package no.nav.familie.kontrakter.ef.søknad
 
-data class Adresse(val gatenavn: String? = null,
-                   val husnummer: Int? = null,
-                   val husbokstav: String? = null,
-                   val bolignummer: String? = null,
+data class Adresse(val adresse: String? = null,
                    val postnummer: String,
                    val poststedsnavn: String? = null,
                    val land: String? = null)

--- a/enslig-forsorger/src/test/kotlin/no/nav/familie/kontrakter/ef/søknad/Testsøknad.kt
+++ b/enslig-forsorger/src/test/kotlin/no/nav/familie/kontrakter/ef/søknad/Testsøknad.kt
@@ -234,10 +234,7 @@ internal object Testsøknad {
 
     private fun adresseSøknadsfelt(): Søknadsfelt<Adresse> {
         return Søknadsfelt("Adresse",
-                           Adresse("Jerpefaret",
-                                   5,
-                                   "C",
-                                   "H0508",
+                           Adresse("Jerpefaret 5C",
                                    "1440",
                                    "Drøbak",
                                    "Norge"))


### PR DESCRIPTION
Forenkler adresse, da nåværende struktur ikke blir brukt. Dersom det blir nødenvdig i forbindelse med saksbehandling kan man hente dette bak senere. familie-ef-soknad-api gir per dags dato kun adresselinje (på samme format som adresseobjekt likevel formaterer det til i pdf) til frontend fra tps-innsyn.