### PR TITLE
Kjeding av utbetalingsperioder

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/Utbetalingsoppdrag.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/Utbetalingsoppdrag.kt
@@ -21,6 +21,8 @@ data class Utbetalingsoppdrag (
 data class Utbetalingsperiode (
     val erEndringPåEksisterendePeriode: Boolean,
     val opphør: Opphør? = null,
+    val periodeId: Long,
+    val forrigePeriodeId: Long? = null,
     val datoForVedtak: LocalDate,
     val klassifisering: String,
     val vedtakdatoFom: LocalDate,


### PR DESCRIPTION
Legger til nye felter slik at man kan identifisere en periode og peke tilbake til forrige periode. 

Vi må samkjøre når vi tar i bruk denne nye versjonen av kontrakten i ba-sak og familie-oppdrag. Ba-sak kan sende over på nytt format uten at familie-oppdrag er oppdatert, men hvis familie-oppdrag tar i bruk periodeId og forrigePeriodeId uten at ba-sak sender det over så blir det krøll. 