### PR TITLE
Behandlingstema

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
@@ -35,16 +35,10 @@ data class Oppgave(
     val endretAv: String? = null,
     val ferdigstiltTidspunkt: String? = null,
     val endretTidspunkt: String? = null,
-    val prioritet: PrioritetEnum? = null,
+    val prioritet: OppgavePrioritet? = null,
     val status: StatusEnum? = null,
     private var metadata: MutableMap<String, String>? = null
 )
-
-enum class PrioritetEnum(private val value: String) {
-    HOY("HOY"),
-    NORM("NORM"),
-    LAV("LAV");
-}
 
 enum class StatusEnum {
     OPPRETTET,

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgave.kt
@@ -32,6 +32,7 @@ enum class Oppgavetype(val value: String) {
 }
 
 enum class Behandlingstema(val value: String) {
+    Barnetrygd("ab0270"),
     BarnetrygdEØS("ab0058"),
     OrdinærBarnetrygd("ab0180"),
     UtvidetBarnetrygd("ab0096")


### PR DESCRIPTION
- Legger til behandlingstemaet som per nå blir brukt i dokumentmetadata for barnetrygdvedtak. 
- Med den nyeste versjonen av pakka kompilerer ikke lenger `OppgaveService` i familie-ba-integrasjoner pga enum-mismatch, da vi har to prioritetsenumer for oppgave. Oppdaterer derfor `Oppgave` til å bruke samme enum som `OpprettOppgave`-requesten den henter data fra.