### PR TITLE
Revert "Skilt mellom hoveddokumenter og vedlegsdokumenter."

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/arkivering/ArkiverDokumentRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/arkivering/ArkiverDokumentRequest.kt
@@ -5,9 +5,7 @@ import javax.validation.constraints.NotEmpty
 
 data class ArkiverDokumentRequest(@field:NotBlank val fnr: String,
                                   val forsøkFerdigstill: Boolean,
-                                  @field:NotEmpty val hoveddokumentvarianter: List<Dokument>,
-                                  val vedleggsdokumenter: List<Dokument> = emptyList(),
+                                  @field:NotEmpty val dokumenter: List<Dokument>,
                                   val fagsakId: String? = null,
-        //Skal ikke settes for innkommende hvis Ruting gjøres av BRUT001
-                                  val journalførendeEnhet: String? = null)
+                                  val journalførendeEnhet: String? = null) //Skal ikke settes for innkommende hvis Ruting gjøres av BRUT001
 


### PR DESCRIPTION
Denne brekker eksisterende funksjonalitet i ba-sak/integrasjoner