### PR TITLE
Legger til ident-type

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/personinfo/Ident.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/personinfo/Ident.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.kontrakter.felles.personinfo
+
+data class Ident (
+        val ident: String
+)


### PR DESCRIPTION
Legger til ident-klasse som brukes i integrasjoner og er duplisert ut i konsumenter (bl.a ba-sak). Disse skal bruke denne i stedet. Identen brukes videre mot endepunkter som selv finner ut av identtypen (personident/fnr, aktørid, osv), så denne klasser trenger ikke holde på denne informasjonen.