### PR TITLE
Ta i bruk én type ident ved snakk om Oppgave

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
@@ -6,7 +6,6 @@ import javax.validation.constraints.Pattern
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Oppgave(val id: Long? = null,
                    val identer: List<OppgaveIdentV2>? = null,
-                   val fnr: String? = null,
                    val tildeltEnhetsnr: String? = null,
                    val endretAvEnhetsnr: String? = null,
                    val eksisterendeOppgaveId: String? = null,

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
@@ -5,6 +5,7 @@ import javax.validation.constraints.Pattern
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Oppgave(val id: Long? = null,
+                   val identer: List<OppgaveIdentV2>? = null,
                    val fnr: String? = null,
                    val tildeltEnhetsnr: String? = null,
                    val endretAvEnhetsnr: String? = null,
@@ -46,4 +47,3 @@ enum class StatusEnum {
     FERDIGSTILT,
     FEILREGISTRERT;
 }
-

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OppgaveIdent.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OppgaveIdent.kt
@@ -9,10 +9,3 @@ enum class IdentGruppe {
     ORGNR,
     SAMHANDLERNR
 }
-
-data class OppgaveIdent(val ident: String, val type: IdentType) // Deprecated
-
-enum class IdentType { // Deprecated
-    Aktør,
-    Organisasjon
-}

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OppgaveIdent.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OppgaveIdent.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.kontrakter.felles.oppgave
+
+data class OppgaveIdentV2(val ident: String, val gruppe: IdentGruppe)
+
+enum class IdentGruppe {
+    AKTOERID,
+    FOLKEREGISTERIDENT,
+    NPID,
+    ORGNR,
+    SAMHANDLERNR
+}
+
+data class OppgaveIdent(val ident: String, val type: IdentType) // Deprecated
+
+enum class IdentType { // Deprecated
+    Aktør,
+    Organisasjon
+}

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgave.kt
@@ -16,13 +16,6 @@ data class OpprettOppgave(val ident: OppgaveIdent?,
                           val prioritet: OppgavePrioritet = OppgavePrioritet.NORM,
                           val behandlingstype: String? = null)
 
-data class OppgaveIdent(val ident: String, val type: IdentType)
-
-enum class IdentType {
-    Aktør,
-    Organisasjon
-}
-
 enum class Oppgavetype(val value: String) {
     BehandleSak("BEH_SAK"),
     Journalføring("JFR"),

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgaveRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgaveRequest.kt
@@ -2,8 +2,7 @@ package no.nav.familie.kontrakter.felles.oppgave
 
 import java.time.LocalDate
 
-@Deprecated("Bruk OpprettOppgaveRequest")
-data class OpprettOppgave(val ident: OppgaveIdent?,
+data class OpprettOppgaveRequest(val ident: OppgaveIdentV2?,
                           val enhetsnummer: String?,
                           val saksId: String?,
                           val journalpostId: String? = null,
@@ -17,11 +16,27 @@ data class OpprettOppgave(val ident: OppgaveIdent?,
                           val prioritet: OppgavePrioritet = OppgavePrioritet.NORM,
                           val behandlingstype: String? = null)
 
-@Deprecated("Bruk OppgaveIdentV2 og IdentGruppe")
-data class OppgaveIdent(val ident: String, val type: IdentType)
+enum class Oppgavetype(val value: String) {
+    BehandleSak("BEH_SAK"),
+    Journalføring("JFR"),
+    GodkjenneVedtak("GOD_VED"),
+    BehandleUnderkjentVedtak("BEH_UND_VED"),
+    Fordeling("FDR")
+}
 
-@Deprecated("Bruk OppgaveIdentV2 og IdentGruppe")
-enum class IdentType {
-    Aktør,
-    Organisasjon
+enum class Behandlingstema(val value: String) {
+    Barnetrygd("ab0270"),
+    BarnetrygdEØS("ab0058"),
+    OrdinærBarnetrygd("ab0180"),
+    UtvidetBarnetrygd("ab0096")
+}
+
+enum class Behandlingstype(val value: String) {
+    Utland("ae0106")
+}
+
+enum class OppgavePrioritet {
+    HOY,
+    NORM,
+    LAV;
 }


### PR DESCRIPTION
- Sånn jeg har forstått det så opereres det nå med en OppgaveIdent for OpprettOppgave som vi bruker internt til å mappe til Oppgave. Denne OppgaveIdent svarer ikke til den som nå innføres på Oppgave. Oppdaterer slik at vi bruker samme type når det er snakk om oppgave.  
- OpprettOppgave -> OpprettOppgaveRequest : Ny versjon med oppdatert navn og som tar i bruk felles OppgaveIdentV2
- Fjern ubrukt fnr-felt. Det ble aldri lagt til av oppgave-gjengen, da identer-feltet ble lagt til i stedet. 

Se relaterte endringer i integrasjoner: 
https://github.com/navikt/familie-integrasjoner/pull/172