### PR TITLE
JsonIgnore etter nytt felt i oppgave

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.kontrakter.felles.oppgave
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import javax.validation.constraints.Pattern
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Oppgave(val id: Long? = null,
                    val identer: List<OppgaveIdentV2>? = null,
                    val tildeltEnhetsnr: String? = null,


### PR DESCRIPTION
**Gamle responser med ny oppgave må kunne håndtere det nye ukjente feltet i gamle responsen til gamle endepunkter**

`Oppgave` blir brukt i `FinnOppgaveResponseDto`. Når vi bumper kontrakt brukt i integrasjoner vil den begynne å returnere Oppgave med nytt identer-felt. Legger på JsonIgnore for at mottakere skal klare å håndtere dette, uten at vi trenger å versjonere DTO og endepunkt igjen, da det allerede ligger flere versjoner ute, men kan også versjonere hvis dere mener det er best :) 

De andre oppgaveendepunktene returnerer kun oppgave-id, hvor det ene blir versjonert pga endring i request.

Fjerner også `@JsonInclude(JsonInclude.Include.NON_NULL)` da jeg tror denne ble lagt til pga fnr-feltet som var null. Stemmer det @henninghaakonsen ?