### PR TITLE
Revertert sletting av JsonInclude.Include.NON_NULL

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
@@ -1,9 +1,11 @@
 package no.nav.familie.kontrakter.felles.oppgave
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 import javax.validation.constraints.Pattern
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class Oppgave(val id: Long? = null,
                    val identer: List<OppgaveIdentV2>? = null,
                    val tildeltEnhetsnr: String? = null,


### PR DESCRIPTION
for å unngå at man får json uten 

"id": null

