### PR TITLE
Skal hente filnavn nfor dokumenter når journalpost hentes ut

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Dokumentvariant.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Dokumentvariant.kt
@@ -1,3 +1,3 @@
 package no.nav.familie.kontrakter.felles.journalpost
 
-data class Dokumentvariant(val variantformat: String)
+data class Dokumentvariant(val variantformat: String, val filnavn: String? = null)


### PR DESCRIPTION
EF setter filnavn til å være vedleggId (som ligger som en del av søknad-json) ved opprettelse av en journalpost og slik kan vi finne tilbake til vedlegg basert på konteksten i søknaden. 