### PR TITLE
Følgende felter er nullbare i AvsenderMottaker for journalpost: id, type, navn, land.

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/AvsenderMottaker.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/AvsenderMottaker.kt
@@ -7,5 +7,5 @@ enum class AvsenderMottakerIdType{
     UKJENT
 }
 
-data class AvsenderMottaker(val id: String, val type: AvsenderMottakerIdType,
-                            val navn: String, val land: String, val erLikBruker: Boolean)
+data class AvsenderMottaker(val id: String?, val type: AvsenderMottakerIdType?,
+                            val navn: String?, val land: String?, val erLikBruker: Boolean)


### PR DESCRIPTION
erLikBruker er ikke nullbar, da den genereres av saf.