### PR TITLE
Utfyllende enum for avsendermottakeridtype

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/AvsenderMottaker.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/AvsenderMottaker.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.kontrakter.felles.journalpost
 
 enum class AvsenderMottakerIdType{
-    NULL,
     FNR,
-    ORGNR,
     HPRNR,
-    UTL_ORG,
-    UKJENT
+    NULL,
+    ORGNR,
+    UKJENT,
+    UTL_ORG
 }
 
 data class AvsenderMottaker(val id: String?, val type: AvsenderMottakerIdType?,

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/AvsenderMottaker.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/AvsenderMottaker.kt
@@ -4,6 +4,8 @@ enum class AvsenderMottakerIdType{
     NULL,
     FNR,
     ORGNR,
+    HPRNR,
+    UTL_ORG,
     UKJENT
 }
 


### PR DESCRIPTION
AvsenderMottakerIdType skal også ha feltene HPRNR og UTL_ORG (ifølge https://confluence.adeo.no/display/BOA/opprettJournalpost).

Ifølge https://confluence.adeo.no/display/BOA/Type%3A+AvsenderMottaker finnes ikke disse feltene, men denne enumen har i tillegg verdiene NULL, UKJENT.

Tar med alle verdiene i denne enumen inntil videre, da det ikke vil feile i deserialiseringen med flere verdier i enumen enn nødvendig. Avklaring trengs for å finne ut av hva som er den korrekte enum-listen.