### PR TITLE
Po c tilgang til noe metadata fra oppgave

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
@@ -7,38 +7,53 @@ import javax.validation.constraints.Pattern
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Oppgave(val id: Long? = null,
-                   val identer: List<OppgaveIdentV2>? = null,
-                   val tildeltEnhetsnr: String? = null,
-                   val endretAvEnhetsnr: String? = null,
-                   val opprettetAvEnhetsnr: String? = null,
-                   val journalpostId: String? = null,
-                   val journalpostkilde: String? = null,
-                   val behandlesAvApplikasjon: String? = null,
-                   val saksreferanse: String? = null,
-                   val bnr: String? = null,
-                   val samhandlernr: String? = null,
-                   @field:Pattern(regexp = "[0-9]{13}")
-                   val aktoerId: String? = null,
-                   val orgnr: String? = null,
-                   val tilordnetRessurs: String? = null,
-                   val beskrivelse: String? = null,
-                   val temagruppe: String? = null,
-                   val tema: Tema? = null,
-                   val behandlingstema: String? = null,
-                   val oppgavetype: String? = null,
-                   val behandlingstype: String? = null,
-                   val versjon: Int? = null,
-                   val mappeId: Long? = null,
-                   val fristFerdigstillelse: String? = null,
-                   val aktivDato: String? = null,
-                   val opprettetTidspunkt: String? = null,
-                   val opprettetAv: String? = null,
-                   val endretAv: String? = null,
-                   val ferdigstiltTidspunkt: String? = null,
-                   val endretTidspunkt: String? = null,
-                   val prioritet: OppgavePrioritet? = null,
-                   val status: StatusEnum? = null,
-                   private var metadata: MutableMap<String, String>? = null)
+        val identer: List<OppgaveIdentV2>? = null,
+        val tildeltEnhetsnr: String? = null,
+        val endretAvEnhetsnr: String? = null,
+        val opprettetAvEnhetsnr: String? = null,
+        val journalpostId: String? = null,
+        val journalpostkilde: String? = null,
+        val behandlesAvApplikasjon: String? = null,
+        val saksreferanse: String? = null,
+        val bnr: String? = null,
+        val samhandlernr: String? = null,
+        @field:Pattern(regexp = "[0-9]{13}")
+        val aktoerId: String? = null,
+        val orgnr: String? = null,
+        val tilordnetRessurs: String? = null,
+        val beskrivelse: String? = null,
+        val temagruppe: String? = null,
+        val tema: Tema? = null,
+        val behandlingstema: String? = null,
+        val oppgavetype: String? = null,
+        val behandlingstype: String? = null,
+        val versjon: Int? = null,
+        val mappeId: Long? = null,
+        val fristFerdigstillelse: String? = null,
+        val aktivDato: String? = null,
+        val opprettetTidspunkt: String? = null,
+        val opprettetAv: String? = null,
+        val endretAv: String? = null,
+        val ferdigstiltTidspunkt: String? = null,
+        val endretTidspunkt: String? = null,
+        val prioritet: OppgavePrioritet? = null,
+        val status: StatusEnum? = null,
+        private var metadata: MutableMap<String, String>? = null,
+) {
+
+    fun leggTilMetadata(key: String, verdi: String) {
+        if (metadata == null) {
+            metadata = mutableMapOf()
+        }
+        metadata!![key] = verdi
+    }
+
+    fun hentMetadata(key : String): String? {
+        return metadata?.get(key)
+    }
+
+
+}
 
 enum class StatusEnum {
     OPPRETTET,

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/Oppgave.kt
@@ -7,38 +7,38 @@ import javax.validation.constraints.Pattern
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Oppgave(val id: Long? = null,
-        val identer: List<OppgaveIdentV2>? = null,
-        val tildeltEnhetsnr: String? = null,
-        val endretAvEnhetsnr: String? = null,
-        val opprettetAvEnhetsnr: String? = null,
-        val journalpostId: String? = null,
-        val journalpostkilde: String? = null,
-        val behandlesAvApplikasjon: String? = null,
-        val saksreferanse: String? = null,
-        val bnr: String? = null,
-        val samhandlernr: String? = null,
-        @field:Pattern(regexp = "[0-9]{13}")
-        val aktoerId: String? = null,
-        val orgnr: String? = null,
-        val tilordnetRessurs: String? = null,
-        val beskrivelse: String? = null,
-        val temagruppe: String? = null,
-        val tema: Tema? = null,
-        val behandlingstema: String? = null,
-        val oppgavetype: String? = null,
-        val behandlingstype: String? = null,
-        val versjon: Int? = null,
-        val mappeId: Long? = null,
-        val fristFerdigstillelse: String? = null,
-        val aktivDato: String? = null,
-        val opprettetTidspunkt: String? = null,
-        val opprettetAv: String? = null,
-        val endretAv: String? = null,
-        val ferdigstiltTidspunkt: String? = null,
-        val endretTidspunkt: String? = null,
-        val prioritet: OppgavePrioritet? = null,
-        val status: StatusEnum? = null,
-        private var metadata: MutableMap<String, String>? = null,
+                   val identer: List<OppgaveIdentV2>? = null,
+                   val tildeltEnhetsnr: String? = null,
+                   val endretAvEnhetsnr: String? = null,
+                   val opprettetAvEnhetsnr: String? = null,
+                   val journalpostId: String? = null,
+                   val journalpostkilde: String? = null,
+                   val behandlesAvApplikasjon: String? = null,
+                   val saksreferanse: String? = null,
+                   val bnr: String? = null,
+                   val samhandlernr: String? = null,
+                   @field:Pattern(regexp = "[0-9]{13}")
+                   val aktoerId: String? = null,
+                   val orgnr: String? = null,
+                   val tilordnetRessurs: String? = null,
+                   val beskrivelse: String? = null,
+                   val temagruppe: String? = null,
+                   val tema: Tema? = null,
+                   val behandlingstema: String? = null,
+                   val oppgavetype: String? = null,
+                   val behandlingstype: String? = null,
+                   val versjon: Int? = null,
+                   val mappeId: Long? = null,
+                   val fristFerdigstillelse: String? = null,
+                   val aktivDato: String? = null,
+                   val opprettetTidspunkt: String? = null,
+                   val opprettetAv: String? = null,
+                   val endretAv: String? = null,
+                   val ferdigstiltTidspunkt: String? = null,
+                   val endretTidspunkt: String? = null,
+                   val prioritet: OppgavePrioritet? = null,
+                   val status: StatusEnum? = null,
+                   private var metadata: MutableMap<String, String>? = null
 ) {
 
     fun leggTilMetadata(key: String, verdi: String) {
@@ -48,7 +48,7 @@ data class Oppgave(val id: Long? = null,
         metadata!![key] = verdi
     }
 
-    fun hentMetadata(key : String): String? {
+    fun hentMetadata(key: String): String? {
         return metadata?.get(key)
     }
 

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/oppgave/OppgaveTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/oppgave/OppgaveTest.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.kontrakter.felles.oppgave
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class OppgaveTest {
+
+    @Test
+    internal fun `Skal kunne legge til og hente ut metadata `() {
+        val oppgave = Oppgave()
+        oppgave.leggTilMetadata("blankett", "true")
+        assertEquals(oppgave.hentMetadata("blankett"), "true")
+    }
+}


### PR DESCRIPTION
Dette er en PoC for å sjekke om vi kan bruke metadata for å kommunisere med oppgavebenk. Er dette en oppgave vi kan starte med behandling i ny løsning (i dette tilfellet en blankettbehandling). 

Vi ønsker å legge inn en enkel "kanBlankettBehandles=true" på oppgaver som har en fagsakId i infotrygd. 

Dette gjør at vi kan identifisere disse oppgavene i oppgavebenken vår. 