### PR TITLE
Utvider FinnOppgaveRequest til å kunne filtrere på saksreferanse

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/FinnOppgaveRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/FinnOppgaveRequest.kt
@@ -12,6 +12,7 @@ data class FinnOppgaveRequest(val tema: Tema,
                               val saksbehandler: String? = null,
                               val aktørId: String? = null,
                               val journalpostId: String? = null,
+                              val saksreferanse: String? = null,
                               val tilordnetRessurs: String? = null,
                               val tildeltRessurs: Boolean? = null,
                               @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)


### PR DESCRIPTION
familie-tilbake har behov for å kunne søke opp oppgaver basert på saksreferanse.