### PR TITLE
Legg til NavKontorEnhet

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/navkontor/NavKontorEnhet.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/navkontor/NavKontorEnhet.kt
@@ -1,0 +1,6 @@
+package no.nav.familie.kontrakter.felles.navkontor
+
+data class NavKontorEnhet(val enhetId: Int,
+                          val navn: String,
+                          val enhetNr: String,
+                          val status: String)


### PR DESCRIPTION
`Enhet` som definert i kontrakter er tilpasset `/api/v1/arbeidsfordeling` fra https://norg2.dev.adeo.no/norg2/swagger-ui.html#/ 

Ser ut til at `/api/v1/enhet/navkontor/{geografiskOmraade}` returnerer en annen enhetstype
