### PR TITLE
Journalpost returnerer value, som vi senere legger inn OppdaterJourna…

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Behandlingstema.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Behandlingstema.kt
@@ -11,4 +11,12 @@ enum class Behandlingstema(val value: String) {
     Kontantstøtte("ab0084"),
     Feilutbetaling("ab0006"),
     Tilbakebetaling("ab0007") // Tilbakekreving
+    ;
+
+    companion object {
+        private val behandlingstemaMap = values().associateBy(Behandlingstema::value)
+        fun fromValue(value: String): Behandlingstema {
+            return behandlingstemaMap[value] ?: throw error("Fant ikke Behandlingstema for value=$value")
+        }
+    }
 }

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Behandlingstema.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Behandlingstema.kt
@@ -1,6 +1,9 @@
 package no.nav.familie.kontrakter.felles
 
-enum class Behandlingstema(val value: String) {
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class Behandlingstema(@JsonValue val value: String) {
     Barnetrygd("ab0270"),
     BarnetrygdEØS("ab0058"),
     OrdinærBarnetrygd("ab0180"),
@@ -14,9 +17,13 @@ enum class Behandlingstema(val value: String) {
     ;
 
     companion object {
-        private val behandlingstemaMap = values().associateBy(Behandlingstema::value)
+        private val behandlingstemaMap = values().associateBy(Behandlingstema::value) + values().associateBy { it.name }
+
+        @JvmStatic
+        @JsonCreator
         fun fromValue(value: String): Behandlingstema {
             return behandlingstemaMap[value] ?: throw error("Fant ikke Behandlingstema for value=$value")
         }
+
     }
 }

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/BehandlingstemaTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/BehandlingstemaTest.kt
@@ -1,14 +1,13 @@
 package no.nav.familie.kontrakter.felles
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.jupiter.api.Test
+import org.junit.Test
 import kotlin.test.assertEquals
 
 internal class BehandlingstemaTest {
     @Test
     internal fun `skal kunne parsea fra enum name`() {
         assertEquals(Behandlingstema.Barnetilsyn, readJsonString(Behandlingstema.Barnetilsyn.name).first())
-
     }
 
     @Test
@@ -18,9 +17,12 @@ internal class BehandlingstemaTest {
 
     @Test
     internal fun `serialisering av behandlingstema skal gi value`() {
-        assertEquals(Behandlingstema.Barnetilsyn.value, objectMapper.writeValueAsString(Behandlingstema.Barnetilsyn))
+        assertEquals(asJsonList(Behandlingstema.Barnetilsyn.value),
+                objectMapper.writeValueAsString(listOf(Behandlingstema.Barnetilsyn)))
     }
 
     private fun readJsonString(s: String) =
-            objectMapper.readValue<List<Behandlingstema>>("[\"$s\"]")
+            objectMapper.readValue<List<Behandlingstema>>(asJsonList(s))
+
+    private fun asJsonList(s: String) = "[\"$s\"]"
 }

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/BehandlingstemaTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/BehandlingstemaTest.kt
@@ -1,0 +1,26 @@
+package no.nav.familie.kontrakter.felles
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class BehandlingstemaTest {
+    @Test
+    internal fun `skal kunne parsea fra enum name`() {
+        assertEquals(Behandlingstema.Barnetilsyn, readJsonString(Behandlingstema.Barnetilsyn.name).first())
+
+    }
+
+    @Test
+    internal fun `skal kunne parsea fra enum value`() {
+        assertEquals(Behandlingstema.Barnetilsyn, readJsonString(Behandlingstema.Barnetilsyn.value).first())
+    }
+
+    @Test
+    internal fun `serialisering av behandlingstema skal gi value`() {
+        assertEquals(Behandlingstema.Barnetilsyn.value, objectMapper.writeValueAsString(Behandlingstema.Barnetilsyn))
+    }
+
+    private fun readJsonString(s: String) =
+            objectMapper.readValue<List<Behandlingstema>>("[\"$s\"]")
+}


### PR DESCRIPTION
…lpostRequest som skal ha enumverdiet av Behandlingstema

Flere feil koblet til denne.
Når vi henter Journalpost så får vi en string, med verdiet `ab0270`
Når vi sen sender denne videre til integrasjoner feiler det i integrasjoner fordi de forventer enum-verdiet. 

I tillegg så sendes den samme DTO'en videre i integrasjoner, med enum name (`Barnetrygd`) i stedet for verdiet `ab0270` så vil sandsynligvis feile i dokarkiv og