### PR TITLE
Utvid bostedsadresse med angittFlyttedato

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/personopplysning/Personinfo.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/personopplysning/Personinfo.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Bostedsadresse(val gyldigFraOgMed: LocalDate? = null,
                           val gyldigTilOgMed: LocalDate? = null,
+                          val angittFlyttedato: LocalDate? = null,
                           val vegadresse: Vegadresse? = null,
                           val matrikkeladresse: Matrikkeladresse? = null,
                           val ukjentBosted: UkjentBosted? = null)


### PR DESCRIPTION
Under saksbehandling vurderer saksbehandler ut i fra datoen personen selv har oppgitt for flyttingen og ikke fregs vedtaksdato, slik vi henter nå (se [doc](https://navikt.github.io/pdl/#opplysningstyper-adresser-bostedsAdresse)).

Dette vil ikke løse alt, men en av tingene i: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5139