### PR TITLE
Utvider TilbakekrevingDto med støtte for feilutbetaling

### DIFF
--- a/enslig-forsorger/pom.xml
+++ b/enslig-forsorger/pom.xml
@@ -15,6 +15,14 @@
 
     <name>Kontrakter - enslig forsørger</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>no.nav.familie.kontrakter</groupId>
+            <artifactId>felles</artifactId>
+            <version>${revision}${sha1}${changelist}</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -8,6 +8,9 @@ import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
 import no.nav.familie.kontrakter.ef.felles.VilkårType
 import no.nav.familie.kontrakter.ef.felles.Vilkårsresultat
+import no.nav.familie.kontrakter.felles.tilbakekreving.Periode
+import no.nav.familie.kontrakter.felles.tilbakekreving.Tilbakekrevingsvalg
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 
@@ -49,7 +52,8 @@ data class VedtaksdetaljerDto(
         val saksbehandlerId: String,
         val beslutterId: String,
         val tilkjentYtelse: TilkjentYtelseDto?,
-        val vedtaksperioder: List<VedtaksperiodeDto> = emptyList()
+        val vedtaksperioder: List<VedtaksperiodeDto> = emptyList(),
+        val feilutbetaling: FeilutbetalingDto? = null
 )
 
 data class VilkårsvurderingDto(
@@ -74,6 +78,18 @@ data class VedtaksperiodeDto(
         val tilOgMed: LocalDate,
         val aktivitet: AktivitetType,
         val periodeType: VedtaksperiodeType
+)
+
+data class FeilutbetalingDto(
+        val tilbakekrevingsvalg: Tilbakekrevingsvalg,
+        // Kreves bare hvis tilbakekrevingsvalg = OPPRETT_TILBAKEKREVING_MED_VARSEL
+        val varseltekst: String?,
+        // Kreves bare hvis tilbakekrevingsvalg = OPPRETT_TILBAKEKREVING_MED_VARSEL.
+        // Hvis det er påkrevd og mangler, så vil det hentes fra simulering
+        val sumFeilutbetaling: BigDecimal?,
+        // Kreves bare hvis tilbakekrevingsvalg = OPPRETT_TILBAKEKREVING_MED_VARSEL.
+        // Hvis det er påkrevd og mangler, så vil det hentes fra simulering
+        val perioder: List<Periode>?
 )
 
 enum class AdressebeskyttelseGradering {

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -53,7 +53,7 @@ data class VedtaksdetaljerDto(
         val beslutterId: String,
         val tilkjentYtelse: TilkjentYtelseDto?,
         val vedtaksperioder: List<VedtaksperiodeDto> = emptyList(),
-        val feilutbetaling: FeilutbetalingDto? = null
+        val tilbakekreving: TilbakekrevingDto? = null
 )
 
 data class VilkårsvurderingDto(
@@ -80,17 +80,14 @@ data class VedtaksperiodeDto(
         val periodeType: VedtaksperiodeType
 )
 
-data class FeilutbetalingDto(
+data class TilbakekrevingDto(
         val tilbakekrevingsvalg: Tilbakekrevingsvalg,
-        // Kreves bare hvis tilbakekrevingsvalg = OPPRETT_TILBAKEKREVING_MED_VARSEL
-        val varseltekst: String?,
-        // Kreves bare hvis tilbakekrevingsvalg = OPPRETT_TILBAKEKREVING_MED_VARSEL.
-        // Hvis det er påkrevd og mangler, så vil det hentes fra simulering
-        val sumFeilutbetaling: BigDecimal?,
-        // Kreves bare hvis tilbakekrevingsvalg = OPPRETT_TILBAKEKREVING_MED_VARSEL.
-        // Hvis det er påkrevd og mangler, så vil det hentes fra simulering
-        val perioder: List<Periode>?
+        val tilbakekrevingMedVarsel: TilbakekrevingMedVarselDto?
 )
+
+data class TilbakekrevingMedVarselDto(val varseltekst: String,
+                                      val sumFeilutbetaling: BigDecimal? = null, // Hentes fra simulering hvis det mangler
+                                      val perioder: List<Periode> = emptyList()) // Hentes fra simulering hvis det mangler
 
 enum class AdressebeskyttelseGradering {
     STRENGT_FORTROLIG,


### PR DESCRIPTION
Et par-tre ting å vurdere her:

- Er det riktig å plassere `tilbakekreving` under `vedtak`? Hadde det først på toppnivået, dvs under `IverksettDto`, men tror vedtak er riktigste kontekst
- Vurderte å kalle feltet `feilutbetaling` i stedet for `tilbakekreving`. Synes nå at `tilbakekreving` bedre reflekterer bruken
- Åpner for å sende over alle felter, men har en tanke om at hvis `sumFeilutbetaling` og `perioder` er påkrevd og mangler, så kjøres det først en simulering i `TilbakekrevingTask`'en. 