### PR TITLE
Fjerner stønadType fra FrittståendeBrevDto fordi iverksett ikke bruke…

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/FrittståendeBrevDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/FrittståendeBrevDto.kt
@@ -2,7 +2,6 @@ package no.nav.familie.kontrakter.ef.felles
 
 data class FrittståendeBrevDto(val personIdent: String,
                                val eksternFagsakId: Long,
-                               val stønadType: StønadType,
                                val brevtype: FrittståendeBrevType,
                                val fil: ByteArray,
                                val journalførendeEnhet: String,


### PR DESCRIPTION
…r denne, og kan utlede det fra fagsak

Merger først denne når `familie-ef-sak` er klar.