### PR TITLE
Gjør id og idType nullable i AvsenderMottaker

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/dokarkiv/AvsenderMottaker.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/dokarkiv/AvsenderMottaker.kt
@@ -2,6 +2,6 @@ package no.nav.familie.kontrakter.felles.dokarkiv
 
 import no.nav.familie.kontrakter.felles.BrukerIdType
 
-class AvsenderMottaker(val id: String,
-                       val idType: BrukerIdType,
+class AvsenderMottaker(val id: String?,
+                       val idType: BrukerIdType?,
                        val navn: String)


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7139
Vi har et case i ba-sak hvor vi ønsker å kun sende inn navn og ikke ident for avsender dersom saksbehandleren ikke har identen til avsender. 

Dette skal være lovlig sett fra arkivet sin side.

![image](https://user-images.githubusercontent.com/17828446/142616297-6d0f057c-ff0c-4a0e-bb8a-e1dba7c92745.png)
