### PR TITLE
Lagt til migrering som årsak til opprettet behandling

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/Vedtak.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/Vedtak.kt
@@ -18,6 +18,7 @@ enum class BehandlingÅrsak {
     SØKNAD,
     NYE_OPPLYSNINGER,
     KLAGE,
+    MIGRERING,
 }
 
 enum class OpphørÅrsak {


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7649

Koblet til å kunne opprette behandling med årsak migrering 
https://github.com/navikt/familie-ef-sak/compare/migrering-infotrygd