### PR TITLE
Opprydding. Fjerner deprecatede enum-verdier da disse ikke er i bruk lengre. Samt…

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/FrittståendeBrevDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/FrittståendeBrevDto.kt
@@ -4,41 +4,13 @@ import no.nav.familie.kontrakter.felles.ef.StønadType
 
 data class FrittståendeBrevDto(val personIdent: String,
                                val eksternFagsakId: Long,
-                               val stønadType: StønadType? = null, // TODO: skal settes til non-nullable når deprecated verdier er brevtyper er fjernet
+                               val stønadType: StønadType,
                                val brevtype: FrittståendeBrevType,
                                val fil: ByteArray,
                                val journalførendeEnhet: String,
                                val saksbehandlerIdent: String)
 
 enum class FrittståendeBrevType(val tittel: String) {
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    MANGELBREV_OVERGANGSSTØNAD("Innhenting av opplysninger"),
-
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    MANGELBREV_BARNETILSYN("Innhenting av opplysninger"),
-
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    MANGELBREV_SKOLEPENGER("Innhenting av opplysninger"),
-
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    INFOBREV_OVERGANGSSTØNAD("Infobrev overgangsstønad"),
-
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    INFOBREV_BARNETILSYN("Infobrev barnetilsyn"),
-
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    INFOBREV_SKOLEPENGER("Infobrev skolepenger"),
-
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    SANKSJONSBREV_OVERGANGSTØNAD("Varsel om sanksjon"),
-
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    SANKSJONSBREV_BARNETILSYN("Varsel om sanksjon"),
-
-    @Deprecated("Skal erstattes av stønads-agnostiske typer")
-    SANKSJONSBREV_SKOLEPENGER("Varsel om sanksjon"),
-
-
     INFORMASJONSBREV("Informasjonsbrev"),
     INNHENTING_AV_OPPLYSNINGER("Innhenting av opplysninger"),
     VARSEL_OM_AKTIVITETSPLIKT("Varsel om aktivitetsplikt"),


### PR DESCRIPTION
…idig må stønadType være non-nullable

Stønadstype persisteres aldri, og kan derfor settes til non-nullable.

Kan først merges etter https://github.com/navikt/familie-ef-iverksett/pull/375 og https://github.com/navikt/familie-ef-sak/pull/1306 er på plass.
