### PR TITLE
Bruk heltall i utgifter (VedtaksperiodeBarnetilsynDto)

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -135,7 +135,7 @@ data class VedtaksperiodeOvergangsstønadDto(
 data class VedtaksperiodeBarnetilsynDto(
         override val fraOgMed: LocalDate,
         override val tilOgMed: LocalDate,
-        val utgifter: BigDecimal,
+        val utgifter: Int,
         val antallBarn: Int
 ) : VedtaksperiodeDto()
 


### PR DESCRIPTION
Ikke tatt i bruk i prod - kan leve med desimalfeil i preprod (hvis det er noen)  