### PR TITLE
Periodetype trengs ikke, setter den til optional for å unngå compile …

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/AndeltilkjentYtelseDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/AndeltilkjentYtelseDto.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 
 data class AndelTilkjentYtelseDto(
         val beløp: Int,
-        var periodetype: Periodetype,
+        var periodetype: Periodetype? = null, // TODO slett denne når den er ubrukt i ef-sak og iverksett, periodetype mappes i utbetalingsgeneratorn basert på stønadstype
         val inntekt: Int,
         val inntektsreduksjon: Int,
         val samordningsfradrag: Int,


### PR DESCRIPTION
…errors i koden, sletter i egen PR

Type utbetaling gjøres i utbetalingsgeneratorn i ef-iverksett ut fra støndstype i stedet

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8678

Koblet til
* https://github.com/navikt/familie-ef-iverksett/pull/465