### PR TITLE
Fikset deserialisering av månedsperiode.

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/ObjectMapper.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/ObjectMapper.kt
@@ -6,7 +6,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.datatype.jsr310.deser.YearMonthDeserializer
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 
 val objectMapper: ObjectMapper
     get() = ObjectMapper()
@@ -15,7 +18,13 @@ val objectMapper: ObjectMapper
         .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
         .setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY)
         .registerKotlinModule()
-        .registerModule(JavaTimeModule())
+        .registerModule(
+            JavaTimeModule()
+                .addDeserializer(
+                    YearMonth::class.java,
+                    YearMonthDeserializer(DateTimeFormatter.ofPattern("u-MM")) // Denne trengs for å parse år over 9999 riktig.
+                )
+        )
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/MånedsperiodeTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/MånedsperiodeTest.kt
@@ -1,10 +1,44 @@
 package no.nav.familie.kontrakter.felles
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.time.YearMonth
 
 internal class MånedsperiodeTest {
+
+    @Test
+    fun `Månedsperiode serialiserer og deserialiserer riktig ved tidenes morgen`() {
+        val månedsperiode = Månedsperiode(LocalDate.MIN, LocalDate.MIN)
+
+        val writeValueAsString = objectMapper.writeValueAsString(månedsperiode)
+
+        val deserialisert = objectMapper.readValue<Månedsperiode>(writeValueAsString)
+
+        månedsperiode shouldBe deserialisert
+    }
+    @Test
+    fun `Månedsperiode serialiserer og deserialiserer riktig ved tidenes ende`() {
+        val månedsperiode = Månedsperiode(LocalDate.MAX, LocalDate.MAX)
+
+        val writeValueAsString = objectMapper.writeValueAsString(månedsperiode)
+
+        val deserialisert = objectMapper.readValue<Månedsperiode>(writeValueAsString)
+
+        månedsperiode shouldBe deserialisert
+    }
+
+    @Test
+    fun `Månedsperiode serialiserer og deserialiserer riktig ved år 0`() {
+        val månedsperiode = Månedsperiode(YearMonth.of(0, 1), YearMonth.of(0, 1))
+
+        val writeValueAsString = objectMapper.writeValueAsString(månedsperiode)
+
+        val deserialisert = objectMapper.readValue<Månedsperiode>(writeValueAsString)
+
+        månedsperiode shouldBe deserialisert
+    }
 
     @Test
     fun `inneholder returnere true hvis måned er i perioden`() {


### PR DESCRIPTION
Deserialisering av YearMonth med år > 9999 havarerer med standard DateTimeFormatter for verdier som er serilaisert med samme objectmapper. 