### PR TITLE
Lagt til gyldig kontantstøtte fagsystem enum-verdi KONT og Deprecated KS

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Fagsystem.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Fagsystem.kt
@@ -3,6 +3,10 @@ package no.nav.familie.kontrakter.felles
 enum class Fagsystem(val navn: String, val tema: String) {
     BA("Barnetrygd", "BAR"),
     EF("Enslig forelder", "ENF"),
-    KS("Kontantstøtte", "KON"),
+
+    @Deprecated(message = "Gyldig verdi for kontantstøtte er KONT")
+    KS("Kontantstøtte - gammel", "KON"),
+
+    KONT("Kontantstøtte", "KON"),
     IT01("Infotrygd", "")
 }


### PR DESCRIPTION
Tidligere har `Fagsystem.KS` blitt brukt om for kontantstøtte. Usikkert om dette noen gang har vært "gyldig". Har nå lagt til `Fagsystem.KONT` som skal være den gyldige verdien for kontantstøtte ([opprettJournalPost](https://confluence.adeo.no/display/BOA/opprettJournalpost)). Har i tillegg annotert gammel verdi med `@Deprecated`

Ref: https://github.com/navikt/familie-integrasjoner/pull/718