### PR TITLE
Legg til informasjon om vedtaket er nasjonalt eller gjelder utland

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Regelverk.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Regelverk.kt
@@ -1,0 +1,6 @@
+package no.nav.familie.kontrakter.felles
+
+enum class Regelverk {
+    NASJONAL,
+    EØS
+}

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/FagsystemVedtak.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/FagsystemVedtak.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.kontrakter.felles.klage
 
+import no.nav.familie.kontrakter.felles.Regelverk
 import java.time.LocalDateTime
 
 data class FagsystemVedtak(
@@ -8,7 +9,7 @@ data class FagsystemVedtak(
     val resultat: String,
     val vedtakstidspunkt: LocalDateTime,
     val fagsystemType: FagsystemType,
-    val nasjonalitetType: NasjonalitetType
+    val regelverk: Regelverk
 )
 
 enum class FagsystemType {
@@ -16,9 +17,4 @@ enum class FagsystemType {
     TILBAKEKREVING,
     SANKSJON_1_MND,
     UTESTENGELSE
-}
-
-enum class NasjonalitetType(dvhKode: String){
-    NASJONAL("Nasjonal"),
-    UTLAND("Utland")
 }

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/FagsystemVedtak.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/FagsystemVedtak.kt
@@ -8,6 +8,7 @@ data class FagsystemVedtak(
     val resultat: String,
     val vedtakstidspunkt: LocalDateTime,
     val fagsystemType: FagsystemType,
+    val nasjonalitetType: NasjonalitetType
 )
 
 enum class FagsystemType {
@@ -15,4 +16,9 @@ enum class FagsystemType {
     TILBAKEKREVING,
     SANKSJON_1_MND,
     UTESTENGELSE
+}
+
+enum class NasjonalitetType(dvhKode: String){
+    NASJONAL("Nasjonal"),
+    UTLAND("Utland")
 }

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/HentFagsystemsbehandlingRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/HentFagsystemsbehandlingRequest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.kontrakter.felles.tilbakekreving
 
+import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.kontrakter.felles.Språkkode
 import java.time.LocalDate
 import javax.validation.Valid

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/OpprettTilbakekrevingRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/OpprettTilbakekrevingRequest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.kontrakter.felles.tilbakekreving
 
 import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.kontrakter.felles.Språkkode
 import java.time.LocalDate
 import javax.validation.Valid

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/Regelverk.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/Regelverk.kt
@@ -1,6 +1,0 @@
-package no.nav.familie.kontrakter.felles.tilbakekreving
-
-enum class Regelverk {
-    NASJONAL,
-    EØS
-}


### PR DESCRIPTION
Vi trenger å vite om et vedtak er najsonalt eller gjelder utland når vi sender stakstatistikk fra klage til datavarehus. 

Sender derfor med om saken er nasjonal eller EØS i `FagsystemVedtak`. 

Måten jeg har løst dette på krever også at vi må endre i KS, BA, EF og tilbakekreving før vi oppdaterer kontrakter i klage