### PR TITLE
erFeilKonto skal ha default value = null for å unngå breaking change …

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/simulering/SimulertPostering.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/simulering/SimulertPostering.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 
 data class SimulertPostering(
     val fagOmrådeKode: FagOmrådeKode,
-    val erFeilkonto: Boolean?, // brukes for å skille manuelle korigeringer og reelle feilutbetalinger
+    val erFeilkonto: Boolean? = null, // brukes for å skille manuelle korigeringer og reelle feilutbetalinger
     val fom: LocalDate,
     val tom: LocalDate,
     val betalingType: BetalingType,


### PR DESCRIPTION
…i kontrakter

For å fikse byggfeil i https://github.com/navikt/familie-ef-iverksett/pull/671