### PR TITLE
Støtte for å utbetale til noe annet enn fnr ved konsistensavstemming

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/PerioderForBehandling.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/PerioderForBehandling.kt
@@ -6,5 +6,9 @@ package no.nav.familie.kontrakter.felles.oppdrag
 data class PerioderForBehandling(
     val behandlingId: String,
     val perioder: Set<Long>,
-    val aktivFødselsnummer: String
+    val aktivFødselsnummer: String,
+    /**
+     * Hvis utbetalingen er til en annen enn aktivFødselsnummer
+     */
+    val utebetalesTil: String? = null
 )


### PR DESCRIPTION
Utvider kontrakt for konsistensavstemming, som gjør det mulig å ha utbetalTil annet enn fnr. Dette for å støtte institusjonssaker, hvor man ikke betaler til aktiv fødselsnummer.