### PR TITLE
Overskriver maven versjon fra runner-image med v3.8.7

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -20,6 +20,11 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
+      - name: Use Maven v3.8.7
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.8.7
+
       - name: Resolve/Update Dependencies
         env:
           GITHUB_USERNAME: x-access-token
@@ -43,4 +48,4 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -e --settings .github/maven-settings.xml source:jar-no-fork deploy -DskipTests=true -Dmaven.wagon.http.pool=false
+        run: mvn --settings .github/maven-settings.xml source:jar-no-fork deploy -DskipTests=true -Dmaven.wagon.http.pool=false

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.0</version>
                 </plugin>


### PR DESCRIPTION
Deploy kaster feil etter at runner-image (`ubuntu-latest`) har begynt å bruke maven `3.9.0`. Som en midlertidig fix overskriver vi maven versjonen med den eldre versjonen `3.8.7`. Spesifiserer også plugin versjon for `maven-install-plugin`. 