### PR TITLE
Endre navn fremleggsoppgave

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -96,7 +96,7 @@ data class VedtaksdetaljerOvergangsstønadDto(
     override val tilbakekreving: TilbakekrevingDto? = null,
     override val brevmottakere: List<Brevmottaker> = emptyList(),
     override val avslagÅrsak: AvslagÅrsak? = null,
-    val opprettFremleggsoppgave: OppgaverForOpprettelseDto = OppgaverForOpprettelseDto(oppgavetyper = emptyList())
+    val oppgaverForOpprettelseDto: OppgaverForOpprettelseDto = OppgaverForOpprettelseDto(oppgavetyper = emptyList())
 ) : VedtaksdetaljerDto()
 
 data class VedtaksdetaljerBarnetilsynDto(

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -223,7 +223,7 @@ data class TilbakekrevingMedVarselDto(
 ) // Hentes fra simulering hvis det mangler
 
 enum class FremleggsoppgaveType {
-    INNTEKT_1_ÅR_FREM_I_TID
+    INNTEKTSKONTROLL_1_ÅR_FREM_I_TID
 }
 
 data class OpprettFremleggsoppgaveDto(val oppgavetyper: List<FremleggsoppgaveType>)

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -96,7 +96,7 @@ data class VedtaksdetaljerOvergangsstønadDto(
     override val tilbakekreving: TilbakekrevingDto? = null,
     override val brevmottakere: List<Brevmottaker> = emptyList(),
     override val avslagÅrsak: AvslagÅrsak? = null,
-    val oppgaverForOpprettelseDto: OppgaverForOpprettelseDto = OppgaverForOpprettelseDto(oppgavetyper = emptyList())
+    val oppgaverForOpprettelse: OppgaverForOpprettelseDto = OppgaverForOpprettelseDto(oppgavetyper = emptyList())
 ) : VedtaksdetaljerDto()
 
 data class VedtaksdetaljerBarnetilsynDto(

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -85,7 +85,7 @@ sealed class VedtaksdetaljerDto {
     abstract val avslagÅrsak: AvslagÅrsak?
 }
 
-data class OpprettFremlegsoppgave(val inntekt: Boolean)
+data class OpprettFremleggsoppgave(val inntekt: Boolean)
 
 data class VedtaksdetaljerOvergangsstønadDto(
     override val resultat: Vedtaksresultat,
@@ -98,7 +98,7 @@ data class VedtaksdetaljerOvergangsstønadDto(
     override val tilbakekreving: TilbakekrevingDto? = null,
     override val brevmottakere: List<Brevmottaker> = emptyList(),
     override val avslagÅrsak: AvslagÅrsak? = null,
-    val opprettFremleggsoppgave: OpprettFremlegsoppgave = OpprettFremlegsoppgave(inntekt = false)
+    val opprettFremleggsoppgave: OpprettFremleggsoppgave = OpprettFremleggsoppgave(inntekt = false)
 ) : VedtaksdetaljerDto()
 
 data class VedtaksdetaljerBarnetilsynDto(

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -96,7 +96,7 @@ data class VedtaksdetaljerOvergangsstønadDto(
     override val tilbakekreving: TilbakekrevingDto? = null,
     override val brevmottakere: List<Brevmottaker> = emptyList(),
     override val avslagÅrsak: AvslagÅrsak? = null,
-    val opprettFremleggsoppgave: OpprettFremleggsoppgaveDto = OpprettFremleggsoppgaveDto(oppgavetyper = emptyList())
+    val opprettFremleggsoppgave: AutomatiskOppgaveDto = AutomatiskOppgaveDto(oppgavetyper = emptyList())
 ) : VedtaksdetaljerDto()
 
 data class VedtaksdetaljerBarnetilsynDto(
@@ -222,11 +222,11 @@ data class TilbakekrevingMedVarselDto(
         ?: error("Perioder eller fellesperioder må ha verdi!")
 ) // Hentes fra simulering hvis det mangler
 
-enum class FremleggsoppgaveType {
+enum class AutomatiskOppgaveType {
     INNTEKTSKONTROLL_1_ÅR_FREM_I_TID
 }
 
-data class OpprettFremleggsoppgaveDto(val oppgavetyper: List<FremleggsoppgaveType>)
+data class AutomatiskOppgaveDto(val oppgavetyper: List<AutomatiskOppgaveType>)
 
 enum class AdressebeskyttelseGradering {
     STRENGT_FORTROLIG,

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -96,7 +96,7 @@ data class VedtaksdetaljerOvergangsstønadDto(
     override val tilbakekreving: TilbakekrevingDto? = null,
     override val brevmottakere: List<Brevmottaker> = emptyList(),
     override val avslagÅrsak: AvslagÅrsak? = null,
-    val opprettFremleggsoppgave: AutomatiskOppgaveDto = AutomatiskOppgaveDto(oppgavetyper = emptyList())
+    val opprettFremleggsoppgave: OppgaverForOpprettelseDto = OppgaverForOpprettelseDto(oppgavetyper = emptyList())
 ) : VedtaksdetaljerDto()
 
 data class VedtaksdetaljerBarnetilsynDto(
@@ -222,11 +222,11 @@ data class TilbakekrevingMedVarselDto(
         ?: error("Perioder eller fellesperioder må ha verdi!")
 ) // Hentes fra simulering hvis det mangler
 
-enum class AutomatiskOppgaveType {
+enum class OppgaveForOpprettelseType {
     INNTEKTSKONTROLL_1_ÅR_FREM_I_TID
 }
 
-data class AutomatiskOppgaveDto(val oppgavetyper: List<AutomatiskOppgaveType>)
+data class OppgaverForOpprettelseDto(val oppgavetyper: List<OppgaveForOpprettelseType>)
 
 enum class AdressebeskyttelseGradering {
     STRENGT_FORTROLIG,

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -96,7 +96,7 @@ data class VedtaksdetaljerOvergangsstønadDto(
     override val tilbakekreving: TilbakekrevingDto? = null,
     override val brevmottakere: List<Brevmottaker> = emptyList(),
     override val avslagÅrsak: AvslagÅrsak? = null,
-    val opprettFremleggsoppgave: OpprettFremleggsoppgaveDto = OpprettFremleggsoppgaveDto(oppgaveTyper = emptyList())
+    val opprettFremleggsoppgave: OpprettFremleggsoppgaveDto = OpprettFremleggsoppgaveDto(oppgavetyper = emptyList())
 ) : VedtaksdetaljerDto()
 
 data class VedtaksdetaljerBarnetilsynDto(

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -223,7 +223,7 @@ data class TilbakekrevingMedVarselDto(
 ) // Hentes fra simulering hvis det mangler
 
 enum class FremleggsoppgaveType {
-    INNTEKT
+    INNTEKT_1_ÅR_FREM_I_TID
 }
 
 data class OpprettFremleggsoppgaveDto(val oppgaveTyper: List<FremleggsoppgaveType>)

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -85,8 +85,6 @@ sealed class VedtaksdetaljerDto {
     abstract val avslagÅrsak: AvslagÅrsak?
 }
 
-data class OpprettFremleggsoppgave(val inntekt: Boolean)
-
 data class VedtaksdetaljerOvergangsstønadDto(
     override val resultat: Vedtaksresultat,
     override val vedtakstidspunkt: LocalDateTime,
@@ -98,7 +96,7 @@ data class VedtaksdetaljerOvergangsstønadDto(
     override val tilbakekreving: TilbakekrevingDto? = null,
     override val brevmottakere: List<Brevmottaker> = emptyList(),
     override val avslagÅrsak: AvslagÅrsak? = null,
-    val opprettFremleggsoppgave: OpprettFremleggsoppgave = OpprettFremleggsoppgave(inntekt = false)
+    val opprettFremleggsoppgave: OpprettFremleggsoppgaveDto = OpprettFremleggsoppgaveDto(oppgaveTyper = emptyList())
 ) : VedtaksdetaljerDto()
 
 data class VedtaksdetaljerBarnetilsynDto(
@@ -223,6 +221,12 @@ data class TilbakekrevingMedVarselDto(
     val fellesperioder: List<Månedsperiode> = perioder?.map { Månedsperiode(it.fom, it.tom) }
         ?: error("Perioder eller fellesperioder må ha verdi!")
 ) // Hentes fra simulering hvis det mangler
+
+enum class FremleggsoppgaveType {
+    INNTEKT
+}
+
+data class OpprettFremleggsoppgaveDto(val oppgaveTyper: List<FremleggsoppgaveType>)
 
 enum class AdressebeskyttelseGradering {
     STRENGT_FORTROLIG,

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -226,7 +226,7 @@ enum class FremleggsoppgaveType {
     INNTEKT_1_ÅR_FREM_I_TID
 }
 
-data class OpprettFremleggsoppgaveDto(val oppgaveTyper: List<FremleggsoppgaveType>)
+data class OpprettFremleggsoppgaveDto(val oppgavetyper: List<FremleggsoppgaveType>)
 
 enum class AdressebeskyttelseGradering {
     STRENGT_FORTROLIG,


### PR DESCRIPTION
Endrer navn på FremleggsoppgaveDto, siden automatiske oppgaver kan ha typer som ikke er fremleggsoppgaver (det er bare én type fremleggsoppgave (inntekt) som skal opprettes automatisk i dag - og så kommer andre typer oppgaver ). 