### PR TITLE
Tilrettelegg for å kunne ta imot og bruke utsendingsinfo på journalpo…

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
@@ -15,6 +15,7 @@ data class Journalpost(
     val dokumenter: List<DokumentInfo>? = null,
     val relevanteDatoer: List<RelevantDato>? = null,
     val eksternReferanseId: String? = null,
+    val utsendingsinfo: Utsendingsinfo? = null,
 ) {
 
     val datoMottatt = relevanteDatoer?.firstOrNull { it.datotype == "DATO_REGISTRERT" }?.dato

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Utsendingsinfo.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Utsendingsinfo.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.kontrakter.felles.journalpost
+
+import no.nav.familie.kontrakter.felles.journalpost.Utsendingsmåte.DIGITAL_POST
+import no.nav.familie.kontrakter.felles.journalpost.Utsendingsmåte.FYSISK_POST
+import java.time.LocalDateTime
+
+data class Utsendingsinfo(
+    val varselSendt: List<VarselSendt> = emptyList(),
+    val fysiskpostSendt: FysiskpostSendt?,
+    val digitalpostSendt: DigitalpostSendt?,
+) {
+
+    val utsendingsmåter = Utsendingsmåte.values().filter {
+        when (it) {
+            FYSISK_POST -> fysiskpostSendt != null
+            DIGITAL_POST -> digitalpostSendt != null
+        }
+    }
+}
+
+data class VarselSendt(
+    val type: VarselType,
+    val varslingstidspunkt: LocalDateTime,
+)
+
+data class FysiskpostSendt(
+    val adressetekstKonvolutt: String,
+)
+
+data class DigitalpostSendt(
+    val adresse: String,
+)
+
+enum class VarselType {
+    SMS,
+    EPOST,
+}
+
+enum class Utsendingsmåte {
+    FYSISK_POST,
+    DIGITAL_POST,
+}

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/UtsendingsinfoTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/UtsendingsinfoTest.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.kontrakter.felles.journalpost
+
+import no.nav.familie.kontrakter.felles.journalpost.Utsendingsmåte.DIGITAL_POST
+import no.nav.familie.kontrakter.felles.journalpost.Utsendingsmåte.FYSISK_POST
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class UtsendingsinfoTest {
+
+    @Test
+    fun `skal utlede utsendingsmåter fra fysisk og digital post `() {
+        assertEquals(emptyList(), Utsendingsinfo(emptyList(), null, null).utsendingsmåter)
+
+        assertEquals(listOf(FYSISK_POST), Utsendingsinfo(emptyList(), FysiskpostSendt("Adresse 1234"), null).utsendingsmåter)
+
+        assertEquals(
+            listOf(DIGITAL_POST),
+            Utsendingsinfo(emptyList(), null, DigitalpostSendt("digital@adresse.no")).utsendingsmåter,
+        )
+
+        assertEquals(
+            listOf(FYSISK_POST, DIGITAL_POST),
+            Utsendingsinfo(
+                emptyList(),
+                FysiskpostSendt("Adresse 1234"),
+                DigitalpostSendt("digital@adresse.no"),
+            ).utsendingsmåter,
+        )
+    }
+}


### PR DESCRIPTION
…ster.

Tanken er at saksbehandlingsløsningene på sikt kan vise frem om en journalpost er distribuert digitalt, fysisk eller ikke-distribuert. Kan også vise når det er sendt ut varsler på en journalpost. 