### PR TITLE
Skal sende med tittel istedenfor brevtype ved utsending av frittstående brev

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/FrittståendeBrevDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/FrittståendeBrevDto.kt
@@ -7,7 +7,9 @@ data class FrittståendeBrevDto(
     val personIdent: String,
     val eksternFagsakId: Long,
     val stønadType: StønadType,
-    val brevtype: FrittståendeBrevType,
+    @Deprecated("Skal erstattes av tittel")
+    val brevtype: FrittståendeBrevType? = null,
+    val tittel: String,
     val fil: ByteArray,
     val journalførendeEnhet: String,
     val saksbehandlerIdent: String,


### PR DESCRIPTION
**Hvorfor?**
Brevtype brukes bare for å utlede tittel. Ved overgang til frittstående sanitybrev ønsker å kunne sette brevtitler (tittel i dokumentoversikt) direkte i sanity, istedenfor å sende med brevtype.

