### PR TITLE
Skal håndtere utfall fra kabal ved oversendelse til trygderetten

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/BehandlingResultat.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/BehandlingResultat.kt
@@ -36,4 +36,6 @@ enum class KlageinstansUtfall(val navn: String) {
     STADFESTELSE("Stadfestelse KA"),
     UGUNST("Ugunst (Ugyldig) KA"),
     AVVIST("Avvist KA"),
+    INNSTILLING_STADFESTELSE("Instilling om stadfestelse til trygderetten fra KA"),
+    INNSTILLING_AVVIST("Instilling om avist til trygderetten fra KA"),
 }


### PR DESCRIPTION
**Hvorfor?**
Vi har fått en hendelse av typen `ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET` fra kabal som foreløpig feiler ved innlesing/håndtering. For å kunne lagre klageresultatet trenger vi disse nye utfallene, som kan forekomme ved denne eventypen.

Visning håndteres i https://github.com/navikt/familie-kontrakter/pull/810