### PR TITLE
Utgifter for skolepenger skal være nullable

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -190,7 +190,8 @@ data class DelårsperiodeSkoleårSkolepengerDto(
 
 data class SkolepengerUtgiftDto(
     val utgiftsdato: LocalDate,
-    val utgifter: Int,
+    @Deprecated("Skal ikke sende med utgifter etter oppdatering av UI.")
+    val utgifter: Int? = null,
     val stønad: Int,
 )
 


### PR DESCRIPTION
Ved overgang til nytt UI skal saksbehandler ikke lengre fylle inn utgifter for skolepenger, men vi må fortsatt i en overgangsperiode støtte ny og gammel UI