### PR TITLE
Skal sende med grunnbeløpsperiode og beløp til iverksett for bruk ved publisering av gomregningsmelding

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -98,6 +98,7 @@ data class VedtaksdetaljerOvergangsstønadDto(
     override val brevmottakere: List<Brevmottaker> = emptyList(),
     override val avslagÅrsak: AvslagÅrsak? = null,
     val oppgaverForOpprettelse: OppgaverForOpprettelseDto = OppgaverForOpprettelseDto(oppgavetyper = emptyList()),
+    val grunnbeløp: Grunnbeløp? = null,
 ) : VedtaksdetaljerDto()
 
 data class VedtaksdetaljerBarnetilsynDto(
@@ -298,3 +299,4 @@ data class Brevmottaker(
         ORGANISASJONSNUMMER,
     }
 }
+data class Grunnbeløp(val periode: Månedsperiode, val grunnbeløp: BigDecimal)


### PR DESCRIPTION
### Hvorfor?
Nå vi iverksetter en behandling med behandlingsårsak `GOmregning` publiserer `familie-ef-iverksett` en melding til bruker med informasjon om Gomregningen (`SendBrukernotifikasjonVedGOmregningTask`). Frem til nå har vi bare hardkodet nyeste grunnbeløp i iverksett. Ulempen med dette er at vi hvert år må huske å oppdatere iverksett med nyeste G. Ved å sende det G med fra ef-sak slipper vi å ha dette i iverksett, og vi kan være sikre på at det brukes riktig grunnbeløp i melding til bruker. 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13586)