### PR TITLE
Legg til avstemmingId

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/GrensesnittavstemmingRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/GrensesnittavstemmingRequest.kt
@@ -1,9 +1,15 @@
 package no.nav.familie.kontrakter.felles.oppdrag
 
 import java.time.LocalDateTime
+import java.util.UUID
 
+/**
+ * @property avstemmingId Unik id for en grenseavsnittsavstemming.
+ * Dersom det er fulllført en grenseavsnittsavstemming på en avstemmingId vil alle fremdtidige grenseavsnittsavstemminger på samme avstemmingId ignoreres.
+ */
 data class GrensesnittavstemmingRequest(
     val fagsystem: String,
     val fra: LocalDateTime,
     val til: LocalDateTime,
+    val avstemmingId: UUID?,
 )

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/GrensesnittavstemmingRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppdrag/GrensesnittavstemmingRequest.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 
 /**
  * @property avstemmingId Unik id for en grenseavsnittsavstemming.
- * Dersom det er fulllført en grenseavsnittsavstemming på en avstemmingId vil alle fremdtidige grenseavsnittsavstemminger på samme avstemmingId ignoreres.
+ * Dersom det er fullført en grenseavsnittsavstemming på en avstemmingId vil alle fremdtidige grenseavsnittsavstemminger på samme avstemmingId ignoreres.
  */
 data class GrensesnittavstemmingRequest(
     val fagsystem: String,


### PR DESCRIPTION
Når vi kjører grensesnittavstemming i ba-sak hender det at avstammingen timer ut før den er ferdig, selv om det går bra mot oppdrag. I de tilfellene har vi ikke lyst til å kjøre grensesnittavstemmingen på nytt. 

Endrer så vi kan sende med en avstemmingId som vil bli lagret i familie-oppdrag. Dersom vi prøver å rekjøre en grenseavsnittsavstemming på samme avstemmingId vil den bli ignorert dersom forrige avstemming gikk ok. 