### PR TITLE
Legger til felter for personident og adresse for utland

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/Utenlandsopphold.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/Utenlandsopphold.kt
@@ -7,4 +7,6 @@ data class Utenlandsopphold(
     val tildato: Søknadsfelt<LocalDate>,
     val land: Søknadsfelt<String>? = null,
     val årsakUtenlandsopphold: Søknadsfelt<String>,
+    val personidentUtland: String? = null,
+    val adresseUtland: String? = null,
 )


### PR DESCRIPTION
Hvorfor ? 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15341

Trenger felter for utenlandsk ID og adresse under Utelandsopphold. 