### PR TITLE
Legger til forrigeBehandlingEksternId slik at det kan sendes til behandlingsstatistikk fra iverksett uten noen ekstra kall

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/iverksett/IverksettDto.kt
@@ -62,6 +62,7 @@ data class FagsakdetaljerDto(
 data class BehandlingsdetaljerDto(
     val behandlingId: UUID,
     val forrigeBehandlingId: UUID? = null,
+    val forrigeBehandlingEksternId: Long? = null,
     val eksternId: Long,
     val behandlingType: BehandlingType,
     val behandlingÅrsak: BehandlingÅrsak,


### PR DESCRIPTION
Det skal nå sendes info til behandlingsstatistikk ved g-omregning. Det blir mest rett å gjøre dette fra iverksett, da det skal kun sendes hendelse når g-omregningen for en behandling er ferdig. Det manglet et felt for å komme i mål med å sende nok info for dette fra iverksett, som var relatertBehandlingEksternId, og velger derfor bare å legge til den her. 