### PR TITLE
Legger til begrunnelseForTilbakekreving

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/OpprettTilbakekrevingRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/OpprettTilbakekrevingRequest.kt
@@ -33,6 +33,7 @@ data class OpprettTilbakekrevingRequest(
     val institusjon: Institusjon? = null,
     @field:Valid
     val manuelleBrevmottakere: Set<Brevmottaker> = emptySet(),
+    val begrunnelseForTilbakekreving: String?
 ) {
 
     init {


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/86f241541982404a7491d82d?card=NAV-20714

Vi ønsker å propagere tekst for hvorfor en tilbakekreving er opprettet fra EF, BA og KS.
Vi må derfor utvide felles requestobjektet.