### PR TITLE
Reverter midlertidige endringer fra #742

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -22,11 +22,6 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      - name: Use Maven v3.8.7
-        uses: stCarolas/setup-maven@v4.5
-        with:
-          maven-version: 3.8.7
-
       - name: Resolve/Update Dependencies
         env:
           GITHUB_USERNAME: x-access-token

--- a/pom.xml
+++ b/pom.xml
@@ -172,11 +172,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>3.2.5</version>
                 </plugin>


### PR DESCRIPTION
Reverter midlertidig endring fra https://github.com/navikt/familie-kontrakter/pull/742

Feil som førte til endringene i #742:
> Deploy kaster feil etter at runner-image (ubuntu-latest) har begynt å bruke maven 3.9.0

Nå fungerer forhåpentligvis den nyeste maven-versjonen igjen. Prøver å reverte det