### PR TITLE
Legger til saksbehandlingstype i behandling for å kunne se om en tilbakekreving er automatisk behandlet

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/Behandling.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/Behandling.kt
@@ -12,6 +12,7 @@ data class Behandling(
     val status: Behandlingsstatus,
     val vedtaksdato: LocalDateTime?,
     val resultat: Behandlingsresultatstype?,
+    val saksbehandlingstype: Saksbehandlingstype,
 )
 
 enum class Behandlingsårsakstype {
@@ -36,4 +37,11 @@ enum class Behandlingsresultatstype {
     DELVIS_TILBAKEBETALING,
     FULL_TILBAKEBETALING,
     HENLAGT,
+}
+
+enum class Saksbehandlingstype {
+    ORDINÆR,
+    AUTOMATISK_IKKE_INNKREVING_LAVT_BELØP,
+    AUTOMATISK_IKKE_INNKREVING_UNDER_4X_RETTSGEBYR,
+    ;
 }


### PR DESCRIPTION
Skal brukes til å vise et varsel i ef-sak dersom noen har fått automatisk behandlet rettsgebyr to ganger tidligere

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20869)