### PR TITLE
Ny versjon av KontantstøtteSøknad (V5) og BarnetrygdSøknad (V9)

### DIFF
--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/BarnetrygdSøknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/BarnetrygdSøknad.kt
@@ -8,7 +8,7 @@ import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v8.Barn
 import no.nav.familie.kontrakter.ba.søknad.v8.Søker
 
-data class Søknad(
+data class BarnetrygdSøknad(
     val kontraktVersjon: Int,
     val antallEøsSteg: Int,
     val søknadstype: Søknadstype,

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/Søknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/Søknad.kt
@@ -1,0 +1,22 @@
+package no.nav.familie.kontrakter.ba.søknad.v9
+
+import no.nav.familie.kontrakter.ba.søknad.v4.Locale
+import no.nav.familie.kontrakter.ba.søknad.v4.SpørsmålId
+import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt
+import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
+import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
+import no.nav.familie.kontrakter.ba.søknad.v8.Barn
+import no.nav.familie.kontrakter.ba.søknad.v8.Søker
+
+data class Søknad(
+    val kontraktVersjon: Int,
+    val antallEøsSteg: Int,
+    val søknadstype: Søknadstype,
+    val søker: Søker,
+    val barn: List<Barn>,
+    val finnesPersonMedAdressebeskyttelse: Boolean,
+    val spørsmål: Map<SpørsmålId, Søknadsfelt<Any>>,
+    val dokumentasjon: List<Søknaddokumentasjon>,
+    val teksterUtenomSpørsmål: Map<SpørsmålId, Map<Locale, String>>,
+    val originalSpråk: Locale,
+)

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v5/KontantstøtteSøknad.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v5/KontantstøtteSøknad.kt
@@ -1,0 +1,2 @@
+package no.nav.familie.kontrakter.ks.søknad.v5
+

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v5/KontantstøtteSøknad.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v5/KontantstøtteSøknad.kt
@@ -1,2 +1,27 @@
 package no.nav.familie.kontrakter.ks.søknad.v5
 
+import no.nav.familie.kontrakter.ks.søknad.v1.Locale
+import no.nav.familie.kontrakter.ks.søknad.v1.Søknaddokumentasjon
+import no.nav.familie.kontrakter.ks.søknad.v1.Søknadsfelt
+import no.nav.familie.kontrakter.ks.søknad.v1.TekstPåSpråkMap
+import no.nav.familie.kontrakter.ks.søknad.v4.Barn
+import no.nav.familie.kontrakter.ks.søknad.v4.Søker
+
+data class KontantstøtteSøknad(
+    val kontraktVersjon: Int,
+    val antallEøsSteg: Int,
+    val søker: Søker,
+    val barn: List<Barn>,
+    val dokumentasjon: List<Søknaddokumentasjon>,
+    val teksterTilPdf: Map<String, TekstPåSpråkMap>,
+    val originalSpråk: Locale,
+    val finnesPersonMedAdressebeskyttelse: Boolean,
+    val erNoenAvBarnaFosterbarn: Søknadsfelt<String>,
+    val søktAsylForBarn: Søknadsfelt<String>,
+    val oppholderBarnSegIInstitusjon: Søknadsfelt<String>,
+    val barnOppholdtSegTolvMndSammenhengendeINorge: Søknadsfelt<String>,
+    val erBarnAdoptert: Søknadsfelt<String>,
+    val mottarKontantstøtteForBarnFraAnnetEøsland: Søknadsfelt<String>,
+    val harEllerTildeltBarnehageplass: Søknadsfelt<String>,
+    val erAvdødPartnerForelder: Søknadsfelt<String>?,
+)


### PR DESCRIPTION
Favro: [NAV-22010](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22010)

* Legger til feltet `finnesPersonMedAdressebeskyttelse` for å kunne skjule søkers adresse i PDF.

Lager ny kontrakt til tross for at `ba-soknad` og `ks-soknad` ikke trenger å sende med noe mer data. Dette for at vi i baks-mottak skal kunne skille mellom søknader vi faktisk har sjekket adressebeskyttelse på og de som ellers ville hatt feltet `finnesPersonMedAdressebeskyttelse` satt til `false` til tross for at vi ikke har sjekket de.