### PR TITLE
Skal bygge kontrakter med java 21 i github. Dette gjør at enum og dat…

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: Build with Maven
         env:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -19,7 +19,7 @@ jobs:
         id: setup-java
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
 
       - name: Resolve/Update Dependencies

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/FinnOppgaveRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/FinnOppgaveRequest.kt
@@ -29,7 +29,7 @@ data class FinnOppgaveRequest(
     val limit: Long? = null,
     val offset: Long? = null,
     val sorteringsfelt: Sorteringsfelt? = null,
-    val sorteringsrekkefølge: Sorteringsrekkefølge? = null
+    val sorteringsrekkefølge: Sorteringsrekkefølge? = null,
 )
 
 enum class Sorteringsfelt {

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/personopplysning/Personinfo.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/personopplysning/Personinfo.kt
@@ -44,7 +44,7 @@ data class Statsborgerskap(
 )
 
 data class Sivilstand(
-    val type: SIVILSTAND,
+    val type: SIVILSTANDTYPE,
     val gyldigFraOgMed: LocalDate? = null,
 )
 
@@ -69,7 +69,7 @@ enum class OPPHOLDSTILLATELSE {
     OPPLYSNING_MANGLER,
 }
 
-enum class SIVILSTAND {
+enum class SIVILSTANDTYPE {
     UOPPGITT,
     UGIFT,
     GIFT,


### PR DESCRIPTION
…a class ikke kan ha samme package og navn - så endrer navn på enum-sivilstand til sivilstandtype.

Dette treffer nok noen applikasjoner i både BAKS og EF-sfæren, men forhåpentligvis ikke voldsomt hardt..?