### PR TITLE
Lagt til enhetsnavn i kontrakt for Enhet

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/enhet/Enhet.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/enhet/Enhet.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.kontrakter.felles.enhet
 
-data class Enhet(val enhetsnummer: String) {
+data class Enhet(val enhetsnummer: String, val enhetsnavn: String) {
     init {
         if (enhetsnummer.length != 4) throw IllegalArgumentException("Enhetsnummer må være 4 siffer")
     }

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/enhet/EnhetTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/enhet/EnhetTest.kt
@@ -10,20 +10,20 @@ class EnhetTest {
     @Test
     fun `skal kunne opprette Enhet dersom enhetsnummer inneholder nøyaktig 4 siffer`() {
         // Act and assert
-        assertDoesNotThrow { Enhet("1234")}
+        assertDoesNotThrow { Enhet("1234", "Navn") }
     }
 
     @Test
     fun `skal kaste feil ved opprettelse av Enhet dersom enhetsnummer inneholder mindre enn 4 siffer`() {
         // Act and assert
-        val exception = assertThrows<IllegalArgumentException> { Enhet("123")}
+        val exception = assertThrows<IllegalArgumentException> { Enhet("123", "Navn") }
         assertEquals("Enhetsnummer må være 4 siffer", exception.message)
     }
 
     @Test
     fun `skal kaste feil ved opprettelse av Enhet dersom enhetsnummer inneholder mer enn 4 siffer`() {
         // Act and assert
-        val exception = assertThrows<IllegalArgumentException> { Enhet("12345")}
+        val exception = assertThrows<IllegalArgumentException> { Enhet("12345", "Navn") }
         assertEquals("Enhetsnummer må være 4 siffer", exception.message)
     }
 }


### PR DESCRIPTION
Vi trenger enhetsnavnet i tillegg til enhetsnummeret for å kunne presentere rett informasjon i saksbehandlingsløsning til barnetrygd og kontantstøtte.