### PR TITLE
NAV-22361: Definerer Brevkoder for barnetrygd og kontantstøtte og utvider Journalpost med hjelpemetoder

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Brevkoder.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Brevkoder.kt
@@ -1,0 +1,9 @@
+package no.nav.familie.kontrakter.felles
+
+object Brevkoder {
+    const val BARNETRYGD_ORDINÆR_SØKNAD = "NAV 33-00.07"
+    const val BARNETRYGD_UTVIDET_SØKNAD = "NAV 33-00.09"
+    const val KONTANTSTØTTE_SØKNAD = "NAV 34-00.08"
+
+    val BARNETRYGD_BREVKODER = listOf(BARNETRYGD_ORDINÆR_SØKNAD, BARNETRYGD_UTVIDET_SØKNAD)
+}

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
@@ -2,7 +2,6 @@ package no.nav.familie.kontrakter.felles.journalpost
 
 import no.nav.familie.kontrakter.felles.Brevkoder
 import no.nav.familie.kontrakter.felles.Tema
-import no.nav.familie.kontrakter.felles.dokdistkanal.Distribusjonskanal
 
 data class Journalpost(
     val journalpostId: String,

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
@@ -1,5 +1,9 @@
 package no.nav.familie.kontrakter.felles.journalpost
 
+import no.nav.familie.kontrakter.felles.Brevkoder
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.dokdistkanal.Distribusjonskanal
+
 data class Journalpost(
     val journalpostId: String,
     val journalposttype: Journalposttype,
@@ -19,4 +23,17 @@ data class Journalpost(
 ) {
 
     val datoMottatt = relevanteDatoer?.firstOrNull { it.datotype == "DATO_REGISTRERT" }?.dato
+
+    fun erDigitalKanal() = this.kanal == "NAV_NO"
+
+    fun erDigitalBarnetrygdSøknad() = erDigitalKanal() && this.dokumenter?.any { dokument -> Brevkoder.BARNETRYGD_BREVKODER.any { brevkode -> brevkode == dokument.brevkode } } ?: false
+
+    fun erDigitalKontantstøtteSøknad() = erDigitalKanal() && this.dokumenter?.any { dokument -> Brevkoder.KONTANTSTØTTE_SØKNAD == dokument.brevkode } ?: false
+
+    fun erDigitalSøknad(tema: Tema): Boolean = when(tema) {
+        Tema.BAR -> erDigitalBarnetrygdSøknad()
+        Tema.KON -> erDigitalKontantstøtteSøknad()
+        else -> throw Error("Støtter ikke tema $tema")
+    }
+
 }

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
@@ -1,0 +1,192 @@
+package no.nav.familie.kontrakter.felles.journalpost
+
+import no.nav.familie.kontrakter.felles.Brevkoder
+import no.nav.familie.kontrakter.felles.Tema
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class JournalpostTest {
+
+    @Test
+    fun `skal returnere true dersom journalpost er digital kontantstøtte søknad og tema er KON`() {
+        //Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            kanal = "NAV_NO",
+            dokumenter = listOf(
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD
+                )
+            )
+        )
+
+        // Act
+        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.KON)
+
+        // Assert
+        assertTrue(erDigitalSøknad)
+    }
+
+    @Test
+    fun `skal returnere false dersom journalpost ikke er digital kontantstøtte søknad og tema er KON`() {
+        //Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            kanal = "NAV_NO",
+            dokumenter = listOf(
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD
+                )
+            )
+        )
+
+        // Act
+        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.KON)
+
+        // Assert
+        assertFalse(erDigitalSøknad)
+    }
+
+    @Test
+    fun `skal returnere false dersom journalpost ikke inneholder noen dokumenter og tema er KON`() {
+        //Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            kanal = "NAV_NO",
+            dokumenter = null
+        )
+
+        // Act
+        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.KON)
+
+        // Assert
+        assertFalse(erDigitalSøknad)
+    }
+
+    @Test
+    fun `skal returnere false dersom journalpost ikke har kommet via digital kanal og tema er KON`() {
+        //Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            kanal = "SKAN_",
+            dokumenter = emptyList()
+        )
+
+        // Act
+        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.KON)
+
+        // Assert
+        assertFalse(erDigitalSøknad)
+    }
+
+    @Test
+    fun `skal returnere true dersom journalpost er digital barnetrygd søknad og tema er BAR`() {
+        //Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            kanal = "NAV_NO",
+            dokumenter = listOf(
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD
+                )
+            )
+        )
+
+        // Act
+        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.BAR)
+
+        // Assert
+        assertTrue(erDigitalSøknad)
+    }
+
+    @Test
+    fun `skal returnere false dersom journalpost ikke er digital barnetrygd søknad og tema er BAR`() {
+        //Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            kanal = "NAV_NO",
+            dokumenter = listOf(
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD
+                )
+            )
+        )
+
+        // Act
+        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.BAR)
+
+        // Assert
+        assertFalse(erDigitalSøknad)
+    }
+
+    @Test
+    fun `skal returnere false dersom journalpost ikke inneholder noen dokumenter og tema er BAR`() {
+        //Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            kanal = "NAV_NO",
+            dokumenter = null
+        )
+
+        // Act
+        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.BAR)
+
+        // Assert
+        assertFalse(erDigitalSøknad)
+    }
+
+    @Test
+    fun `skal returnere false dersom journalpost ikke har kommet via digital kanal og tema er BAR`() {
+        //Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT,
+            kanal = "SKAN_",
+            dokumenter = emptyList()
+        )
+
+        // Act
+        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.BAR)
+
+        // Assert
+        assertFalse(erDigitalSøknad)
+    }
+
+    @Test
+    fun `skal kaste feil dersom tema enda ikke er støttet`() {
+        // Arrange
+        val journalpost = Journalpost(
+            journalpostId = "123",
+            journalposttype = Journalposttype.I,
+            journalstatus = Journalstatus.MOTTATT
+        )
+
+        // Act
+        val error = assertThrows<Error> { journalpost.erDigitalSøknad(Tema.ENF) }
+
+        // Assert
+        assertEquals(expected = "Støtter ikke tema ${Tema.ENF}", actual = error.message)
+    }
+}


### PR DESCRIPTION
Legger til hjelpemetoder i `Journalpost` for å sjekke om journalposten er en digital barnetrygd eller kontantstøtte søknad. Dette for å unngå mye duplikat kode i appene våre.