### PR TITLE
Legger til TilgangsstyrtJournalpost

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/TilgangsstyrtJournalpost.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/TilgangsstyrtJournalpost.kt
@@ -1,0 +1,6 @@
+package no.nav.familie.kontrakter.felles.journalpost
+
+data class TilgangsstyrtJournalpost(
+    val journalpost: Journalpost,
+    val harTilgang: Boolean
+)


### PR DESCRIPTION
Favro: [NAV-22361](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22361)

Vi har behov for å sjekke saksbehandlers tilgang til journalposter for digitale søknader. Trenger derfor et nytt retur-objekt ved henting av journalposter som inneholder informasjon om hvorvidt saksbehandler skal ha tilgang til å se innholdet i dokumentene til journalposten eller ikke.