### PR TITLE
Justerer extension-functions for Journalpost og legger til extension-functions for DokumentInfo

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfo.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfo.kt
@@ -1,10 +1,25 @@
 package no.nav.familie.kontrakter.felles.journalpost
 
+import no.nav.familie.kontrakter.felles.Brevkoder
+import no.nav.familie.kontrakter.felles.Tema
+
 data class DokumentInfo(
     val dokumentInfoId: String,
     val tittel: String? = null,
     val brevkode: String? = null,
     val dokumentstatus: Dokumentstatus? = null,
     val dokumentvarianter: List<Dokumentvariant>? = null,
-    val logiskeVedlegg: List<LogiskVedlegg>? = null,
-)
+    val logiskeVedlegg: List<LogiskVedlegg>? = null) {
+
+    fun erDigitalBarnetrygdSøknad() =
+        Brevkoder.BARNETRYGD_BREVKODER.any { brevkode -> brevkode == this.brevkode }
+
+    fun erDigitalKontantstøtteSøknad() =
+        Brevkoder.KONTANTSTØTTE_SØKNAD == this.brevkode
+
+    fun erDigitalSøknad(tema: Tema): Boolean = when (tema) {
+        Tema.BAR -> erDigitalBarnetrygdSøknad()
+        Tema.KON -> erDigitalKontantstøtteSøknad()
+        else -> throw Error("Støtter ikke tema $tema")
+    }
+}

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.kontrakter.felles.journalpost
 
-import no.nav.familie.kontrakter.felles.Brevkoder
 import no.nav.familie.kontrakter.felles.Tema
 
 data class Journalpost(
@@ -25,13 +24,13 @@ data class Journalpost(
 
     fun erDigitalKanal() = this.kanal == "NAV_NO"
 
-    fun erDigitalBarnetrygdSøknad() = erDigitalKanal() && this.dokumenter?.any { dokument -> Brevkoder.BARNETRYGD_BREVKODER.any { brevkode -> brevkode == dokument.brevkode } } ?: false
+    fun harDigitalBarnetrygdSøknad() = erDigitalKanal() && this.dokumenter?.any { it.erDigitalBarnetrygdSøknad()} ?: false
 
-    fun erDigitalKontantstøtteSøknad() = erDigitalKanal() && this.dokumenter?.any { dokument -> Brevkoder.KONTANTSTØTTE_SØKNAD == dokument.brevkode } ?: false
+    fun harDigitalKontantstøtteSøknad() = erDigitalKanal() && this.dokumenter?.any { it.erDigitalKontantstøtteSøknad() } ?: false
 
-    fun erDigitalSøknad(tema: Tema): Boolean = when(tema) {
-        Tema.BAR -> erDigitalBarnetrygdSøknad()
-        Tema.KON -> erDigitalKontantstøtteSøknad()
+    fun harDigitalSøknad(tema: Tema): Boolean = when(tema) {
+        Tema.BAR -> harDigitalBarnetrygdSøknad()
+        Tema.KON -> harDigitalKontantstøtteSøknad()
         else -> throw Error("Støtter ikke tema $tema")
     }
 

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
@@ -1,0 +1,79 @@
+package no.nav.familie.kontrakter.felles.journalpost
+
+import no.nav.familie.kontrakter.felles.Brevkoder
+import no.nav.familie.kontrakter.felles.Tema
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DokumentInfoTest {
+
+
+    @Nested
+    inner class ErDigitalSøknad {
+
+        @Test
+        fun`skal returnere true dersom DokumentInfo har brevkode som passer med tema BAR`() {
+            // Arrange
+            val dokumentInfo = DokumentInfo(
+                dokumentInfoId = "1",
+                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD
+            )
+
+            // Act & Assert
+            assertTrue { dokumentInfo.erDigitalSøknad(Tema.BAR) }
+        }
+
+        @Test
+        fun`skal returnere false dersom DokumentInfo har brevkode som ikke passer med tema BAR`() {
+            // Arrange
+            val dokumentInfo = DokumentInfo(
+                dokumentInfoId = "1",
+                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD
+            )
+
+            // Act & Assert
+            assertFalse { dokumentInfo.erDigitalSøknad(Tema.BAR) }
+        }
+
+        @Test
+        fun`skal returnere true dersom DokumentInfo har brevkode som passer med tema KON`() {
+            // Arrange
+            val dokumentInfo = DokumentInfo(
+                dokumentInfoId = "1",
+                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD
+            )
+
+            // Act & Assert
+            assertTrue { dokumentInfo.erDigitalSøknad(Tema.KON) }
+        }
+
+        @Test
+        fun`skal returnere false dersom DokumentInfo har brevkode som ikke passer med tema KON`() {
+            // Arrange
+            val dokumentInfo = DokumentInfo(
+                dokumentInfoId = "1",
+                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD
+            )
+
+            // Act & Assert
+            assertFalse { dokumentInfo.erDigitalSøknad(Tema.KON) }
+        }
+
+        @Test
+        fun`skal kaste feil dersom tema ikke er støttet`() {
+            // Arrange
+            val dokumentInfo = DokumentInfo(
+                dokumentInfoId = "1",
+                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD
+            )
+
+            // Act & Assert
+            val error = assertThrows<Error> { dokumentInfo.erDigitalSøknad(Tema.ENF) }
+            assertEquals("Støtter ikke tema ENF", error.message)
+        }
+    }
+}

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
@@ -27,7 +27,7 @@ class JournalpostTest {
         )
 
         // Act
-        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.KON)
+        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
 
         // Assert
         assertTrue(erDigitalSøknad)
@@ -50,7 +50,7 @@ class JournalpostTest {
         )
 
         // Act
-        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.KON)
+        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
 
         // Assert
         assertFalse(erDigitalSøknad)
@@ -68,7 +68,7 @@ class JournalpostTest {
         )
 
         // Act
-        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.KON)
+        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
 
         // Assert
         assertFalse(erDigitalSøknad)
@@ -86,7 +86,7 @@ class JournalpostTest {
         )
 
         // Act
-        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.KON)
+        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
 
         // Assert
         assertFalse(erDigitalSøknad)
@@ -109,7 +109,7 @@ class JournalpostTest {
         )
 
         // Act
-        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.BAR)
+        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
 
         // Assert
         assertTrue(erDigitalSøknad)
@@ -132,7 +132,7 @@ class JournalpostTest {
         )
 
         // Act
-        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.BAR)
+        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
 
         // Assert
         assertFalse(erDigitalSøknad)
@@ -150,7 +150,7 @@ class JournalpostTest {
         )
 
         // Act
-        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.BAR)
+        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
 
         // Assert
         assertFalse(erDigitalSøknad)
@@ -168,7 +168,7 @@ class JournalpostTest {
         )
 
         // Act
-        val erDigitalSøknad = journalpost.erDigitalSøknad(Tema.BAR)
+        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
 
         // Assert
         assertFalse(erDigitalSøknad)
@@ -184,7 +184,7 @@ class JournalpostTest {
         )
 
         // Act
-        val error = assertThrows<Error> { journalpost.erDigitalSøknad(Tema.ENF) }
+        val error = assertThrows<Error> { journalpost.harDigitalSøknad(Tema.ENF) }
 
         // Assert
         assertEquals(expected = "Støtter ikke tema ${Tema.ENF}", actual = error.message)


### PR DESCRIPTION
For å kunne bestemme om en Journalpost inneholder en digital søknad og om et bestemt dokument er en digital søknad, legger vi her til extension-functions som hjelper oss med dette.