### PR TITLE
Sealed class for 2 siste versjoner av BA og KS søknadene

### DIFF
--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknad.kt
@@ -27,9 +27,9 @@ class VersjonertBarnetrygdSøknadDeserializer : JsonDeserializer<VersjonertBarne
                 ?: throw MissingVersionException("JSON-string mangler feltet 'kontraktVersjon' og kan ikke deserialiseres. $node")
 
         return when (versjon) {
-            7 -> VersjonertBarnetrygdSøknadV7(baksSøknadBase = p.codec.treeToValue(node, BarnetrygdSøknadV7::class.java))
-            8 -> VersjonertBarnetrygdSøknadV8(baksSøknadBase = p.codec.treeToValue(node, BarnetrygdSøknadV8::class.java))
-            9 -> VersjonertBarnetrygdSøknadV9(baksSøknadBase = p.codec.treeToValue(node, BarnetrygdSøknadV9::class.java))
+            7 -> VersjonertBarnetrygdSøknadV7(barnetrygdSøknad = p.codec.treeToValue(node, BarnetrygdSøknadV7::class.java))
+            8 -> VersjonertBarnetrygdSøknadV8(barnetrygdSøknad = p.codec.treeToValue(node, BarnetrygdSøknadV8::class.java))
+            9 -> VersjonertBarnetrygdSøknadV9(barnetrygdSøknad = p.codec.treeToValue(node, BarnetrygdSøknadV9::class.java))
             else -> throw UnsupportedVersionException("Mangler implementasjon for versjon: $versjon av BarnetrygdSøknad.")
         }
     }
@@ -37,17 +37,22 @@ class VersjonertBarnetrygdSøknadDeserializer : JsonDeserializer<VersjonertBarne
 
 @JsonDeserialize(using = VersjonertBarnetrygdSøknadDeserializer::class)
 sealed class VersjonertBarnetrygdSøknad(
-    open val baksSøknadBase: BaksSøknadBase,
+    open val barnetrygdSøknad: BaksSøknadBase,
 )
 
+// Egen sealed class for versjoner av barnetrygdsøknad vi støtter ved mottak. Dette vil være de 2 siste versjonene til enhver tid.
+sealed class StøttetVersjonertBarnetrygdSøknad(
+    override val barnetrygdSøknad: BaksSøknadBase,
+) : VersjonertBarnetrygdSøknad(barnetrygdSøknad = barnetrygdSøknad)
+
 data class VersjonertBarnetrygdSøknadV7(
-    override val baksSøknadBase: BarnetrygdSøknadV7,
-) : VersjonertBarnetrygdSøknad(baksSøknadBase = baksSøknadBase)
+    override val barnetrygdSøknad: BarnetrygdSøknadV7,
+) : VersjonertBarnetrygdSøknad(barnetrygdSøknad = barnetrygdSøknad)
 
 data class VersjonertBarnetrygdSøknadV8(
-    override val baksSøknadBase: BarnetrygdSøknadV8,
-) : VersjonertBarnetrygdSøknad(baksSøknadBase = baksSøknadBase)
+    override val barnetrygdSøknad: BarnetrygdSøknadV8,
+) : StøttetVersjonertBarnetrygdSøknad(barnetrygdSøknad = barnetrygdSøknad)
 
 data class VersjonertBarnetrygdSøknadV9(
-    override val baksSøknadBase: BarnetrygdSøknadV9,
-) : VersjonertBarnetrygdSøknad(baksSøknadBase = baksSøknadBase)
+    override val barnetrygdSøknad: BarnetrygdSøknadV9,
+) : StøttetVersjonertBarnetrygdSøknad(barnetrygdSøknad = barnetrygdSøknad)

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknadDeserializerTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknadDeserializerTest.kt
@@ -49,11 +49,11 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
         // Assert
         assertNotNull(versjonertBarnetrygdSøknad)
         assertTrue(versjonertBarnetrygdSøknad is VersjonertBarnetrygdSøknadV9)
-        assertEquals(9, versjonertBarnetrygdSøknad.baksSøknadBase.kontraktVersjon)
-        assertEquals(2, versjonertBarnetrygdSøknad.baksSøknadBase.personerISøknad().size)
+        assertEquals(9, versjonertBarnetrygdSøknad.barnetrygdSøknad.kontraktVersjon)
+        assertEquals(2, versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad().size)
         assertEquals(
             listOf("12345678910", "12345678911"),
-            versjonertBarnetrygdSøknad.baksSøknadBase.personerISøknad(),
+            versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad(),
         )
     }
 
@@ -82,11 +82,11 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
         // Assert
         assertNotNull(versjonertBarnetrygdSøknad)
         assertTrue(versjonertBarnetrygdSøknad is VersjonertBarnetrygdSøknadV8)
-        assertEquals(8, versjonertBarnetrygdSøknad.baksSøknadBase.kontraktVersjon)
-        assertEquals(2, versjonertBarnetrygdSøknad.baksSøknadBase.personerISøknad().size)
+        assertEquals(8, versjonertBarnetrygdSøknad.barnetrygdSøknad.kontraktVersjon)
+        assertEquals(2, versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad().size)
         assertEquals(
             listOf("12345678910", "12345678911"),
-            versjonertBarnetrygdSøknad.baksSøknadBase.personerISøknad(),
+            versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad(),
         )
     }
 
@@ -115,11 +115,11 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
         // Assert
         assertNotNull(versjonertBarnetrygdSøknad)
         assertTrue(versjonertBarnetrygdSøknad is VersjonertBarnetrygdSøknadV7)
-        assertEquals(7, versjonertBarnetrygdSøknad.baksSøknadBase.kontraktVersjon)
-        assertEquals(2, versjonertBarnetrygdSøknad.baksSøknadBase.personerISøknad().size)
+        assertEquals(7, versjonertBarnetrygdSøknad.barnetrygdSøknad.kontraktVersjon)
+        assertEquals(2, versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad().size)
         assertEquals(
             listOf("12345678910", "12345678911"),
-            versjonertBarnetrygdSøknad.baksSøknadBase.personerISøknad(),
+            versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad(),
         )
     }
 
@@ -164,16 +164,16 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             utenlandsperioder = emptyList(),
@@ -195,16 +195,16 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             utenlandsperioder = emptyList(),
             arbeidsperioderUtland = emptyList(),

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknadDeserializerTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknadDeserializerTest.kt
@@ -58,6 +58,40 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
     }
 
     @Test
+    fun `skal kunne deserialisere BarnetrygdSøknadV9 til StøttetVersjonertBarnetrygdSøknadV9 når kontraktVersjon er 9`() {
+        // Arrange
+        val søkerFnr = "12345678910"
+        val barnFnr = "12345678911"
+        val barnetrygdSøknadV9 =
+            BarnetrygdSøknadV9(
+                kontraktVersjon = 9,
+                søker = lagSøkerV8(søkerFnr),
+                barn = listOf(lagBarnV8(barnFnr)),
+                antallEøsSteg = 0,
+                dokumentasjon = emptyList(),
+                originalSpråk = "NB",
+                finnesPersonMedAdressebeskyttelse = false,
+                søknadstype = Søknadstype.ORDINÆR,
+                spørsmål = emptyMap(),
+                teksterUtenomSpørsmål = emptyMap(),
+            )
+        val søknadJson = objectMapper.writeValueAsString(barnetrygdSøknadV9)
+
+        // Act
+        val versjonertBarnetrygdSøknad = objectMapper.readValue<StøttetVersjonertBarnetrygdSøknad>(søknadJson)
+
+        // Assert
+        assertNotNull(versjonertBarnetrygdSøknad)
+        assertTrue(versjonertBarnetrygdSøknad is VersjonertBarnetrygdSøknadV9)
+        assertEquals(9, versjonertBarnetrygdSøknad.barnetrygdSøknad.kontraktVersjon)
+        assertEquals(2, versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad().size)
+        assertEquals(
+            listOf("12345678910", "12345678911"),
+            versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad(),
+        )
+    }
+
+    @Test
     fun `skal kunne deserialisere BarnetrygdSøknad V8 når kontraktVersjon er 8`() {
         // Arrange
         val søkerFnr = "12345678910"
@@ -78,6 +112,39 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
 
         // Act
         val versjonertBarnetrygdSøknad = objectMapper.readValue<VersjonertBarnetrygdSøknad>(søknadJson)
+
+        // Assert
+        assertNotNull(versjonertBarnetrygdSøknad)
+        assertTrue(versjonertBarnetrygdSøknad is VersjonertBarnetrygdSøknadV8)
+        assertEquals(8, versjonertBarnetrygdSøknad.barnetrygdSøknad.kontraktVersjon)
+        assertEquals(2, versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad().size)
+        assertEquals(
+            listOf("12345678910", "12345678911"),
+            versjonertBarnetrygdSøknad.barnetrygdSøknad.personerISøknad(),
+        )
+    }
+
+    @Test
+    fun `skal kunne deserialisere BarnetrygdSøknadV8 til StøttetVersjonertBarnetrygdSøknad når kontraktVersjon er 8`() {
+        // Arrange
+        val søkerFnr = "12345678910"
+        val barnFnr = "12345678911"
+        val barnetrygdSøknadV9 =
+            BarnetrygdSøknadV8(
+                kontraktVersjon = 8,
+                søker = lagSøkerV8(søkerFnr),
+                barn = listOf(lagBarnV8(barnFnr)),
+                antallEøsSteg = 0,
+                dokumentasjon = emptyList(),
+                originalSpråk = "NB",
+                søknadstype = Søknadstype.ORDINÆR,
+                spørsmål = emptyMap(),
+                teksterUtenomSpørsmål = emptyMap(),
+            )
+        val søknadJson = objectMapper.writeValueAsString(barnetrygdSøknadV9)
+
+        // Act
+        val versjonertBarnetrygdSøknad = objectMapper.readValue<StøttetVersjonertBarnetrygdSøknad>(søknadJson)
 
         // Assert
         assertNotNull(versjonertBarnetrygdSøknad)
@@ -164,16 +231,16 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
+                lagStringSøknadsfelt(
+                    SøknadAdresse(
+                        adressenavn = "Gate",
+                        postnummer = null,
+                        husbokstav = null,
+                        bruksenhetsnummer = null,
+                        husnummer = null,
+                        poststed = null,
+                    ),
                 ),
-            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             utenlandsperioder = emptyList(),
@@ -195,16 +262,16 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
+                lagStringSøknadsfelt(
+                    SøknadAdresse(
+                        adressenavn = "Gate",
+                        postnummer = null,
+                        husbokstav = null,
+                        bruksenhetsnummer = null,
+                        husnummer = null,
+                        poststed = null,
+                    ),
                 ),
-            ),
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             utenlandsperioder = emptyList(),
             arbeidsperioderUtland = emptyList(),

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknad.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknad.kt
@@ -44,7 +44,7 @@ sealed class VersjonertKontantstøtteSøknad(
     open val kontantstøtteSøknad: BaksSøknadBase,
 )
 
-// Egen sealed class for versjoner av barnetrygdsøknad vi støtter ved mottak. Dette vil være de 2 siste versjonene til enhver tid.
+// Egen sealed class for versjoner av kontantstøttesøknad vi støtter ved mottak. Dette vil være de 2 siste versjonene til enhver tid.
 sealed class StøttetVersjonertKontantstøtteSøknad(
     override val kontantstøtteSøknad: BaksSøknadBase,
 ) : VersjonertKontantstøtteSøknad(kontantstøtteSøknad = kontantstøtteSøknad)

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknad.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknad.kt
@@ -29,11 +29,11 @@ class VersjonertKontantstøtteSøknadDeserializer : JsonDeserializer<VersjonertK
                 ?: throw MissingVersionException("JSON-string mangler feltet 'kontraktVersjon' og kan ikke deserialiseres. $node")
 
         return when (versjon) {
-            1 -> VersjonertKontantstøtteSøknadV1(baksSøknadBase = p.codec.treeToValue(node, KontantstøtteSøknadV1::class.java))
-            2 -> VersjonertKontantstøtteSøknadV2(baksSøknadBase = p.codec.treeToValue(node, KontantstøtteSøknadV2::class.java))
-            3 -> VersjonertKontantstøtteSøknadV3(baksSøknadBase = p.codec.treeToValue(node, KontantstøtteSøknadV3::class.java))
-            4 -> VersjonertKontantstøtteSøknadV4(baksSøknadBase = p.codec.treeToValue(node, KontantstøtteSøknadV4::class.java))
-            5 -> VersjonertKontantstøtteSøknadV5(baksSøknadBase = p.codec.treeToValue(node, KontantstøtteSøknadV5::class.java))
+            1 -> VersjonertKontantstøtteSøknadV1(kontantstøtteSøknad = p.codec.treeToValue(node, KontantstøtteSøknadV1::class.java))
+            2 -> VersjonertKontantstøtteSøknadV2(kontantstøtteSøknad = p.codec.treeToValue(node, KontantstøtteSøknadV2::class.java))
+            3 -> VersjonertKontantstøtteSøknadV3(kontantstøtteSøknad = p.codec.treeToValue(node, KontantstøtteSøknadV3::class.java))
+            4 -> VersjonertKontantstøtteSøknadV4(kontantstøtteSøknad = p.codec.treeToValue(node, KontantstøtteSøknadV4::class.java))
+            5 -> VersjonertKontantstøtteSøknadV5(kontantstøtteSøknad = p.codec.treeToValue(node, KontantstøtteSøknadV5::class.java))
             else -> throw UnsupportedVersionException("Mangler implementasjon for versjon: $versjon av KontantstøtteSøknad.")
         }
     }
@@ -41,25 +41,30 @@ class VersjonertKontantstøtteSøknadDeserializer : JsonDeserializer<VersjonertK
 
 @JsonDeserialize(using = VersjonertKontantstøtteSøknadDeserializer::class)
 sealed class VersjonertKontantstøtteSøknad(
-    open val baksSøknadBase: BaksSøknadBase,
+    open val kontantstøtteSøknad: BaksSøknadBase,
 )
 
+// Egen sealed class for versjoner av barnetrygdsøknad vi støtter ved mottak. Dette vil være de 2 siste versjonene til enhver tid.
+sealed class StøttetVersjonertKontantstøtteSøknad(
+    override val kontantstøtteSøknad: BaksSøknadBase,
+) : VersjonertKontantstøtteSøknad(kontantstøtteSøknad = kontantstøtteSøknad)
+
 data class VersjonertKontantstøtteSøknadV1(
-    override val baksSøknadBase: KontantstøtteSøknadV1,
-) : VersjonertKontantstøtteSøknad(baksSøknadBase = baksSøknadBase)
+    override val kontantstøtteSøknad: KontantstøtteSøknadV1,
+) : VersjonertKontantstøtteSøknad(kontantstøtteSøknad = kontantstøtteSøknad)
 
 data class VersjonertKontantstøtteSøknadV2(
-    override val baksSøknadBase: KontantstøtteSøknadV2,
-) : VersjonertKontantstøtteSøknad(baksSøknadBase = baksSøknadBase)
+    override val kontantstøtteSøknad: KontantstøtteSøknadV2,
+) : VersjonertKontantstøtteSøknad(kontantstøtteSøknad = kontantstøtteSøknad)
 
 data class VersjonertKontantstøtteSøknadV3(
-    override val baksSøknadBase: KontantstøtteSøknadV3,
-) : VersjonertKontantstøtteSøknad(baksSøknadBase = baksSøknadBase)
+    override val kontantstøtteSøknad: KontantstøtteSøknadV3,
+) : VersjonertKontantstøtteSøknad(kontantstøtteSøknad = kontantstøtteSøknad)
 
 data class VersjonertKontantstøtteSøknadV4(
-    override val baksSøknadBase: KontantstøtteSøknadV4,
-) : VersjonertKontantstøtteSøknad(baksSøknadBase = baksSøknadBase)
+    override val kontantstøtteSøknad: KontantstøtteSøknadV4,
+) : StøttetVersjonertKontantstøtteSøknad(kontantstøtteSøknad = kontantstøtteSøknad)
 
 data class VersjonertKontantstøtteSøknadV5(
-    override val baksSøknadBase: KontantstøtteSøknadV5,
-) : VersjonertKontantstøtteSøknad(baksSøknadBase = baksSøknadBase)
+    override val kontantstøtteSøknad: KontantstøtteSøknadV5,
+) : StøttetVersjonertKontantstøtteSøknad(kontantstøtteSøknad = kontantstøtteSøknad)

--- a/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknadDeserializerTest.kt
+++ b/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknadDeserializerTest.kt
@@ -28,7 +28,7 @@ import no.nav.familie.kontrakter.ks.søknad.v5.KontantstøtteSøknad as Kontants
 
 class VersjonertKontantstøtteSøknadDeserializerTest {
     @Test
-    fun`skal kunne deserialisere KontantstøtteSøknad V5`() {
+    fun`skal kunne deserialisere KontantstøtteSøknad V5 til VersjonertKontantstøtteSøknad`() {
         // Arrange
         val søkerFnr = "12345678910"
         val barnFnr = "12345678911"
@@ -65,6 +65,43 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
     }
 
     @Test
+    fun`skal kunne deserialisere KontantstøtteSøknad V5 til StøttetVersjonertKontantstøtteSøknad`() {
+        // Arrange
+        val søkerFnr = "12345678910"
+        val barnFnr = "12345678911"
+        val kontantstøtteSøknadV5 =
+            KontantstøtteSøknadV5(
+                kontraktVersjon = 5,
+                søker = lagSøkerV4(søkerFnr),
+                barn = listOf(lagBarnV4(barnFnr)),
+                antallEøsSteg = 0,
+                dokumentasjon = emptyList(),
+                teksterTilPdf = emptyMap(),
+                originalSpråk = "NB",
+                finnesPersonMedAdressebeskyttelse = false,
+                erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
+                søktAsylForBarn = lagStringSøknadsfelt("Nei"),
+                oppholderBarnSegIInstitusjon = lagStringSøknadsfelt("Nei"),
+                barnOppholdtSegTolvMndSammenhengendeINorge = lagStringSøknadsfelt("Ja"),
+                erBarnAdoptert = lagStringSøknadsfelt("Nei"),
+                mottarKontantstøtteForBarnFraAnnetEøsland = lagStringSøknadsfelt("Nei"),
+                harEllerTildeltBarnehageplass = lagStringSøknadsfelt("Nei"),
+                erAvdødPartnerForelder = null,
+            )
+        val søknadJson = objectMapper.writeValueAsString(kontantstøtteSøknadV5)
+
+        // Act
+        val versjonertKontantstøtteSøknad = objectMapper.readValue<StøttetVersjonertKontantstøtteSøknad>(søknadJson)
+
+        // Assert
+        assertNotNull(versjonertKontantstøtteSøknad)
+        assertTrue { versjonertKontantstøtteSøknad is VersjonertKontantstøtteSøknadV5 }
+        assertEquals(5, versjonertKontantstøtteSøknad.kontantstøtteSøknad.kontraktVersjon)
+        assertEquals(2, versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad().size)
+        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad())
+    }
+
+    @Test
     fun`skal kunne deserialisere KontantstøtteSøknad V4`() {
         // Arrange
         val søkerFnr = "12345678910"
@@ -91,6 +128,42 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
 
         // Act
         val versjonertKontantstøtteSøknad = objectMapper.readValue<VersjonertKontantstøtteSøknad>(søknadJson)
+
+        // Assert
+        assertNotNull(versjonertKontantstøtteSøknad)
+        assertTrue { versjonertKontantstøtteSøknad is VersjonertKontantstøtteSøknadV4 }
+        assertEquals(4, versjonertKontantstøtteSøknad.kontantstøtteSøknad.kontraktVersjon)
+        assertEquals(2, versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad().size)
+        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad())
+    }
+
+    @Test
+    fun`skal kunne deserialisere KontantstøtteSøknad V4 til StøttetVersjonertKontantstøtteSøknad`() {
+        // Arrange
+        val søkerFnr = "12345678910"
+        val barnFnr = "12345678911"
+        val kontantstøtteSøknadV4 =
+            KontantstøtteSøknadV4(
+                kontraktVersjon = 4,
+                søker = lagSøkerV4(søkerFnr),
+                barn = listOf(lagBarnV4(barnFnr)),
+                antallEøsSteg = 0,
+                dokumentasjon = emptyList(),
+                teksterTilPdf = emptyMap(),
+                originalSpråk = "NB",
+                erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
+                søktAsylForBarn = lagStringSøknadsfelt("Nei"),
+                oppholderBarnSegIInstitusjon = lagStringSøknadsfelt("Nei"),
+                barnOppholdtSegTolvMndSammenhengendeINorge = lagStringSøknadsfelt("Ja"),
+                erBarnAdoptert = lagStringSøknadsfelt("Nei"),
+                mottarKontantstøtteForBarnFraAnnetEøsland = lagStringSøknadsfelt("Nei"),
+                harEllerTildeltBarnehageplass = lagStringSøknadsfelt("Nei"),
+                erAvdødPartnerForelder = null,
+            )
+        val søknadJson = objectMapper.writeValueAsString(kontantstøtteSøknadV4)
+
+        // Act
+        val versjonertKontantstøtteSøknad = objectMapper.readValue<StøttetVersjonertKontantstøtteSøknad>(søknadJson)
 
         // Assert
         assertNotNull(versjonertKontantstøtteSøknad)
@@ -249,16 +322,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
+                lagStringSøknadsfelt(
+                    SøknadAdresse(
+                        adressenavn = "Gate",
+                        postnummer = null,
+                        husbokstav = null,
+                        bruksenhetsnummer = null,
+                        husnummer = null,
+                        poststed = null,
+                    ),
                 ),
-            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,
@@ -289,16 +362,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
+                lagStringSøknadsfelt(
+                    SøknadAdresse(
+                        adressenavn = "Gate",
+                        postnummer = null,
+                        husbokstav = null,
+                        bruksenhetsnummer = null,
+                        husnummer = null,
+                        poststed = null,
+                    ),
                 ),
-            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,
@@ -328,16 +401,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
+                lagStringSøknadsfelt(
+                    SøknadAdresse(
+                        adressenavn = "Gate",
+                        postnummer = null,
+                        husbokstav = null,
+                        bruksenhetsnummer = null,
+                        husnummer = null,
+                        poststed = null,
+                    ),
                 ),
-            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,

--- a/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknadDeserializerTest.kt
+++ b/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknadDeserializerTest.kt
@@ -59,9 +59,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
         // Assert
         assertNotNull(versjonertKontantstøtteSøknad)
         assertTrue { versjonertKontantstøtteSøknad is VersjonertKontantstøtteSøknadV5 }
-        assertEquals(5, versjonertKontantstøtteSøknad.baksSøknadBase.kontraktVersjon)
-        assertEquals(2, versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad().size)
-        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad())
+        assertEquals(5, versjonertKontantstøtteSøknad.kontantstøtteSøknad.kontraktVersjon)
+        assertEquals(2, versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad().size)
+        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad())
     }
 
     @Test
@@ -95,9 +95,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
         // Assert
         assertNotNull(versjonertKontantstøtteSøknad)
         assertTrue { versjonertKontantstøtteSøknad is VersjonertKontantstøtteSøknadV4 }
-        assertEquals(4, versjonertKontantstøtteSøknad.baksSøknadBase.kontraktVersjon)
-        assertEquals(2, versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad().size)
-        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad())
+        assertEquals(4, versjonertKontantstøtteSøknad.kontantstøtteSøknad.kontraktVersjon)
+        assertEquals(2, versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad().size)
+        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad())
     }
 
     @Test
@@ -131,9 +131,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
         // Assert
         assertNotNull(versjonertKontantstøtteSøknad)
         assertTrue { versjonertKontantstøtteSøknad is VersjonertKontantstøtteSøknadV3 }
-        assertEquals(3, versjonertKontantstøtteSøknad.baksSøknadBase.kontraktVersjon)
-        assertEquals(2, versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad().size)
-        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad())
+        assertEquals(3, versjonertKontantstøtteSøknad.kontantstøtteSøknad.kontraktVersjon)
+        assertEquals(2, versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad().size)
+        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad())
     }
 
     @Test
@@ -167,9 +167,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
         // Assert
         assertNotNull(versjonertKontantstøtteSøknad)
         assertTrue { versjonertKontantstøtteSøknad is VersjonertKontantstøtteSøknadV2 }
-        assertEquals(2, versjonertKontantstøtteSøknad.baksSøknadBase.kontraktVersjon)
-        assertEquals(2, versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad().size)
-        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad())
+        assertEquals(2, versjonertKontantstøtteSøknad.kontantstøtteSøknad.kontraktVersjon)
+        assertEquals(2, versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad().size)
+        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad())
     }
 
     @Test
@@ -203,9 +203,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
         // Assert
         assertNotNull(versjonertKontantstøtteSøknad)
         assertTrue { versjonertKontantstøtteSøknad is VersjonertKontantstøtteSøknadV1 }
-        assertEquals(1, versjonertKontantstøtteSøknad.baksSøknadBase.kontraktVersjon)
-        assertEquals(2, versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad().size)
-        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.baksSøknadBase.personerISøknad())
+        assertEquals(1, versjonertKontantstøtteSøknad.kontantstøtteSøknad.kontraktVersjon)
+        assertEquals(2, versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad().size)
+        assertEquals(listOf("12345678910", "12345678911"), versjonertKontantstøtteSøknad.kontantstøtteSøknad.personerISøknad())
     }
 
     @Test
@@ -249,16 +249,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,
@@ -289,16 +289,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,
@@ -328,16 +328,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,


### PR DESCRIPTION
Legger til `StøttetVersjonertBarnetrygdSøknad` og `StøttetVersjonertKontantstøtteSøknad` og bruker disse for å definere et subset av henholdsvis `VersjonertBarnetrygdSøknad` og `VersjonertKontantstøtteSøknad`. Subset'ene er i første omgang ment til å brukes i `familie-baks-mottak` og skal inneholde de 2 siste versjonene av søknadskontraktene.

Renamer også feltet `baksSøknadBase` -> `barnetrygdSøknad` og `kontantstøtteSøknad`.