### PR TITLE
Postnummer og poststed kan være tomme felter

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/Brevmottaker.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilbakekreving/Brevmottaker.kt
@@ -39,9 +39,9 @@ data class ManuellAdresseInfo(
     val adresselinje1: String,
     @field:Pattern(regexp = "^(.{0,80})\$", message = "Feltet kan ikke inneholde mer enn 80 tegn")
     val adresselinje2: String? = null,
-    @field:Pattern(regexp = "^(.{1,10})\$", message = "Feltet kan ikke være tomt eller innholde mer enn 10 tegn")
+    @field:Pattern(regexp = "^(.{0,10})\$", message = "Feltet kan ikke innholde mer enn 10 tegn")
     val postnummer: String,
-    @field:Pattern(regexp = "^(.{1,50})\$", message = "Feltet kan ikke være tomt eller innholde mer enn 50 tegn")
+    @field:Pattern(regexp = "^(.{0,50})\$", message = "Feltet kan ikke innholde mer enn 50 tegn")
     val poststed: String,
     @field:Pattern(regexp = "^[a-zA-Z]{2}$", message = "Landkode må følge ISO standard, alpha-2")
     val landkode: String,


### PR DESCRIPTION
I Brevmottaker som familie-tilbake bruker har `postnummer` og `poststed` vært satt til obligatoriske felter på `ManuellAdresseInfo`.

På adresser i utlandet ønsker vi ikke å sende med postnummer og poststed, siden Dokdist ikke tar hensyn til disse feltene. All informasjon skal da legges i adresselinjene. Fikser dermed valideringen til å akseptere tomme strenger.

Jeg setter ikke disse feltene til nullable fordi vi da også må gjøre en jobb med databasen. Og i de fleste tilfellene ønsker vi jo at postnummer og poststed skal inkluderes. Har forankret dette med @bragejahren.