### PR TITLE
Nytt utfall og type fra KA -> medhold etter omgjøringskrav.

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/BehandlingResultat.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/BehandlingResultat.kt
@@ -30,6 +30,7 @@ enum class BehandlingEventType {
     ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET, // TODO ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET skal fjernes på sikt
     BEHANDLING_FEILREGISTRERT,
     BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
+    OMGJOERINGSKRAV_AVSLUTTET,
 }
 
 enum class KlageinstansUtfall(val navn: String) {
@@ -44,4 +45,5 @@ enum class KlageinstansUtfall(val navn: String) {
     INNSTILLING_STADFESTELSE("Innstilling om stadfestelse til trygderetten fra KA"),
     INNSTILLING_AVVIST("Innstilling om avist til trygderetten fra KA"),
     HEVET("Hevet KA"),
+    MEDHOLD_ETTER_FVL_35("Medhold etter fvl. § 35 KA"),
 }


### PR DESCRIPTION
"Medhold etter fvl. § 35 KA"
Brukere kan sende krav om at klageinstansen omgjør et av sine tidligere vedtak, og dette kalles omgjøringskrav. Dersom et omgjøringskrav fører til et medhold, må vedtaksinstans kobles på for å effektuere. familie-klage må kunne håndtere hendelser med denne typen og dette utfallet.