### PR TITLE
NAV-22890: Forenkler logikken og skriver tester for DokumentInfo og Journalpost klassene

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfo.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfo.kt
@@ -11,16 +11,18 @@ data class DokumentInfo(
     val dokumentvarianter: List<Dokumentvariant>? = null,
     val logiskeVedlegg: List<LogiskVedlegg>? = null,
 ) {
+    fun erBarnetrygdOrdinærSøknad() = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD == this.brevkode
 
-    fun erDigitalBarnetrygdSøknad() =
-        Brevkoder.BARNETRYGD_BREVKODER.any { brevkode -> brevkode == this.brevkode }
+    fun erBarnetrygdUtvidetSøknad() = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD == this.brevkode
 
-    fun erDigitalKontantstøtteSøknad() =
-        Brevkoder.KONTANTSTØTTE_SØKNAD == this.brevkode
+    fun erBarnetrygdSøknad() = Brevkoder.BARNETRYGD_BREVKODER.any { brevkode -> brevkode == this.brevkode }
 
-    fun erDigitalSøknad(tema: Tema): Boolean = when (tema) {
-        Tema.BAR -> erDigitalBarnetrygdSøknad()
-        Tema.KON -> erDigitalKontantstøtteSøknad()
-        else -> throw Error("Støtter ikke tema $tema")
-    }
+    fun erKontantstøtteSøknad() = Brevkoder.KONTANTSTØTTE_SØKNAD == this.brevkode
+
+    fun erSøknadForTema(tema: Tema): Boolean =
+        when (tema) {
+            Tema.BAR -> erBarnetrygdSøknad()
+            Tema.KON -> erKontantstøtteSøknad()
+            else -> throw Error("Støtter ikke tema $tema")
+        }
 }

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
@@ -19,30 +19,28 @@ data class Journalpost(
     val eksternReferanseId: String? = null,
     val utsendingsinfo: Utsendingsinfo? = null,
 ) {
-
     val datoMottatt = relevanteDatoer?.firstOrNull { it.datotype == "DATO_REGISTRERT" }?.dato
 
-    fun erDigitalKanal() = this.kanal == "NAV_NO"
+    fun erDigitalKanal() = kanal == "NAV_NO"
 
-    fun harKontantstøtteSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 34-00.08" } ?: false
+    fun harKontantstøtteSøknad(): Boolean = dokumenter?.any { it.erKontantstøtteSøknad() } ?: false
 
-    fun harBarnetrygdOrdinærSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 33-00.07" } ?: false
+    fun harBarnetrygdOrdinærSøknad(): Boolean = dokumenter?.any { it.erBarnetrygdOrdinærSøknad() } ?: false
 
-    fun harBarnetrygdUtvidetSøknad(): Boolean = dokumenter?.any { it.brevkode == "NAV 33-00.09" } ?: false
+    fun harBarnetrygdUtvidetSøknad(): Boolean = dokumenter?.any { it.erBarnetrygdUtvidetSøknad() } ?: false
 
     fun harBarnetrygdSøknad(): Boolean = harBarnetrygdOrdinærSøknad() || harBarnetrygdUtvidetSøknad()
 
-    fun harDigitalBarnetrygdSøknad() =
-        erDigitalKanal() && this.dokumenter?.any { it.erDigitalBarnetrygdSøknad() } ?: false
+    fun harDigitalBarnetrygdSøknad() = erDigitalKanal() && dokumenter?.any { it.erBarnetrygdSøknad() } ?: false
 
-    fun harDigitalKontantstøtteSøknad() =
-        erDigitalKanal() && this.dokumenter?.any { it.erDigitalKontantstøtteSøknad() } ?: false
+    fun harDigitalKontantstøtteSøknad() = erDigitalKanal() && dokumenter?.any { it.erKontantstøtteSøknad() } ?: false
 
-    fun harDigitalSøknad(tema: Tema): Boolean = when (tema) {
-        Tema.BAR -> harDigitalBarnetrygdSøknad()
-        Tema.KON -> harDigitalKontantstøtteSøknad()
-        else -> throw Error("Støtter ikke tema $tema")
-    }
+    fun harDigitalSøknad(tema: Tema): Boolean =
+        when (tema) {
+            Tema.BAR -> harDigitalBarnetrygdSøknad()
+            Tema.KON -> harDigitalKontantstøtteSøknad()
+            else -> throw Error("Støtter ikke tema $tema")
+        }
 
     fun hentHovedDokumentTittel(): String? {
         if (dokumenter.isNullOrEmpty()) error("Journalpost $journalpostId mangler dokumenter")

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
@@ -10,68 +10,291 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DokumentInfoTest {
+    @Nested
+    inner class ErBarnetrygdOrdinærSøknadTest {
+        @Test
+        fun `skal returnere true om brevkode er for ordinær barnetrygd søknad`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                )
+
+            // Act
+            val erBarnetrygdOrdinærSøknad = dokumentInfo.erBarnetrygdOrdinærSøknad()
+
+            // Assert
+            assertTrue(erBarnetrygdOrdinærSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om brevkode ikke er for ordinær barnetrygd søknad`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                )
+
+            // Act
+            val erBarnetrygdOrdinærSøknad = dokumentInfo.erBarnetrygdOrdinærSøknad()
+
+            // Assert
+            assertFalse(erBarnetrygdOrdinærSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om brevkode er null`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = null,
+                )
+
+            // Act
+            val erBarnetrygdOrdinærSøknad = dokumentInfo.erBarnetrygdOrdinærSøknad()
+
+            // Assert
+            assertFalse(erBarnetrygdOrdinærSøknad)
+        }
+    }
 
     @Nested
-    inner class ErDigitalSøknad {
-
+    inner class ErBarnetrygdUtvidetSøknadTest {
         @Test
-        fun`skal returnere true dersom DokumentInfo har brevkode som passer med tema BAR`() {
+        fun `skal returnere true om brevkode er for utvidet barnetrygd søknad`() {
             // Arrange
-            val dokumentInfo = DokumentInfo(
-                dokumentInfoId = "1",
-                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-            )
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                )
 
-            // Act & Assert
-            assertTrue { dokumentInfo.erDigitalSøknad(Tema.BAR) }
+            // Act
+            val erBarnetrygdUtvidetSøknad = dokumentInfo.erBarnetrygdUtvidetSøknad()
+
+            // Assert
+            assertTrue(erBarnetrygdUtvidetSøknad)
         }
 
         @Test
-        fun`skal returnere false dersom DokumentInfo har brevkode som ikke passer med tema BAR`() {
+        fun `skal returnere false om brevkode ikke er for utvidet barnetrygd søknad`() {
             // Arrange
-            val dokumentInfo = DokumentInfo(
-                dokumentInfoId = "1",
-                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-            )
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                )
 
-            // Act & Assert
-            assertFalse { dokumentInfo.erDigitalSøknad(Tema.BAR) }
+            // Act
+            val erBarnetrygdUtvidetSøknad = dokumentInfo.erBarnetrygdUtvidetSøknad()
+
+            // Assert
+            assertFalse(erBarnetrygdUtvidetSøknad)
         }
 
         @Test
-        fun`skal returnere true dersom DokumentInfo har brevkode som passer med tema KON`() {
+        fun `skal returnere false om brevkode er null`() {
             // Arrange
-            val dokumentInfo = DokumentInfo(
-                dokumentInfoId = "1",
-                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-            )
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = null,
+                )
 
-            // Act & Assert
-            assertTrue { dokumentInfo.erDigitalSøknad(Tema.KON) }
+            // Act
+            val erBarnetrygdUtvidetSøknad = dokumentInfo.erBarnetrygdUtvidetSøknad()
+
+            // Assert
+            assertFalse(erBarnetrygdUtvidetSøknad)
+        }
+    }
+
+    @Nested
+    inner class ErBarnetrygdSøknadTest {
+        @Test
+        fun `skal returnere true om brevkode er utvidet barnetrygd søknad`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                )
+
+            // Act
+            val erBarnetrygdUtvidetSøknad = dokumentInfo.erBarnetrygdSøknad()
+
+            // Assert
+            assertTrue(erBarnetrygdUtvidetSøknad)
         }
 
         @Test
-        fun`skal returnere false dersom DokumentInfo har brevkode som ikke passer med tema KON`() {
+        fun `skal returnere true om brevkode er ordinær barnetrygd søknad`() {
             // Arrange
-            val dokumentInfo = DokumentInfo(
-                dokumentInfoId = "1",
-                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
-            )
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                )
 
-            // Act & Assert
-            assertFalse { dokumentInfo.erDigitalSøknad(Tema.KON) }
+            // Act
+            val erBarnetrygdUtvidetSøknad = dokumentInfo.erBarnetrygdSøknad()
+
+            // Assert
+            assertTrue(erBarnetrygdUtvidetSøknad)
         }
 
         @Test
-        fun`skal kaste feil dersom tema ikke er støttet`() {
+        fun `skal returnere false om brevkode er for noe annet enn barnetrygd`() {
             // Arrange
-            val dokumentInfo = DokumentInfo(
-                dokumentInfoId = "1",
-                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-            )
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                )
+
+            // Act
+            val erBarnetrygdUtvidetSøknad = dokumentInfo.erBarnetrygdSøknad()
+
+            // Assert
+            assertFalse(erBarnetrygdUtvidetSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om brevkode er null`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = null,
+                )
+
+            // Act
+            val erBarnetrygdUtvidetSøknad = dokumentInfo.erBarnetrygdSøknad()
+
+            // Assert
+            assertFalse(erBarnetrygdUtvidetSøknad)
+        }
+    }
+
+    @Nested
+    inner class ErKontantstøtteSøknadTest {
+        @Test
+        fun `skal returnere true om brevkode er for kontantstøtte`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                )
+
+            // Act
+            val erKontantstøtteSøknad = dokumentInfo.erKontantstøtteSøknad()
+
+            // Assert
+            assertTrue(erKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om brevkode ikke er for kontantstøtte søknad`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                )
+
+            // Act
+            val erKontantstøtteSøknad = dokumentInfo.erKontantstøtteSøknad()
+
+            // Assert
+            assertFalse(erKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om brevkode er null`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = null,
+                )
+
+            // Act
+            val erKontantstøtteSøknad = dokumentInfo.erKontantstøtteSøknad()
+
+            // Assert
+            assertFalse(erKontantstøtteSøknad)
+        }
+    }
+
+    @Nested
+    inner class ErSøknadForTemaTest {
+        @Test
+        fun `skal returnere true dersom DokumentInfo har brevkode som passer med tema BAR`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                )
 
             // Act & Assert
-            val error = assertThrows<Error> { dokumentInfo.erDigitalSøknad(Tema.ENF) }
+            assertTrue { dokumentInfo.erSøknadForTema(Tema.BAR) }
+        }
+
+        @Test
+        fun `skal returnere false dersom DokumentInfo har brevkode som ikke passer med tema BAR`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                )
+
+            // Act & Assert
+            assertFalse { dokumentInfo.erSøknadForTema(Tema.BAR) }
+        }
+
+        @Test
+        fun `skal returnere true dersom DokumentInfo har brevkode som passer med tema KON`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                )
+
+            // Act & Assert
+            assertTrue { dokumentInfo.erSøknadForTema(Tema.KON) }
+        }
+
+        @Test
+        fun `skal returnere false dersom DokumentInfo har brevkode som ikke passer med tema KON`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                )
+
+            // Act & Assert
+            assertFalse { dokumentInfo.erSøknadForTema(Tema.KON) }
+        }
+
+        @Test
+        fun `skal kaste feil dersom tema ikke er støttet`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                )
+
+            // Act & Assert
+            val error = assertThrows<Error> { dokumentInfo.erSøknadForTema(Tema.ENF) }
             assertEquals("Støtter ikke tema ENF", error.message)
         }
     }

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
@@ -4,189 +4,942 @@ import no.nav.familie.kontrakter.felles.Brevkoder
 import no.nav.familie.kontrakter.felles.Tema
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class JournalpostTest {
+    @Nested
+    inner class DatoMottattTest {
+        @Test
+        fun `skal returnere null om relevante datoer er tom`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    relevanteDatoer = emptyList(),
+                )
 
-    @Test
-    fun `skal returnere true dersom journalpost er digital kontantstøtte søknad og tema er KON`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-            kanal = "NAV_NO",
-            dokumenter = listOf(
-                DokumentInfo(
-                    dokumentInfoId = "1",
-                    brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                ),
-            ),
-        )
+            // Act
+            val datoMottatt = journalpost.datoMottatt
 
-        // Act
-        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
+            // Assert
+            assertNull(datoMottatt)
+        }
 
-        // Assert
-        assertTrue(erDigitalSøknad)
+        @Test
+        fun `skal returnere null om relevante datoer ikke har riktig datotype`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    relevanteDatoer =
+                    listOf(
+                        RelevantDato(
+                            dato = LocalDateTime.of(2024, 8, 1, 12, 0),
+                            datotype = "FEIL_DATOTYPE",
+                        ),
+                    ),
+                )
+
+            // Act
+            val datoMottatt = journalpost.datoMottatt
+
+            // Assert
+            assertNull(datoMottatt)
+        }
+
+        @Test
+        fun `skal returnere mottatt dato`() {
+            // Arrange
+            val enDato = LocalDateTime.of(2024, 8, 1, 12, 0)
+
+            val journalpost =
+                lagJournalpost(
+                    relevanteDatoer =
+                    listOf(
+                        RelevantDato(
+                            dato = enDato,
+                            datotype = "DATO_REGISTRERT",
+                        ),
+                    ),
+                )
+
+            // Act
+            val datoMottatt = journalpost.datoMottatt
+
+            // Assert
+            assertEquals(datoMottatt, enDato)
+        }
     }
 
-    @Test
-    fun `skal returnere false dersom journalpost ikke er digital kontantstøtte søknad og tema er KON`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-            kanal = "NAV_NO",
-            dokumenter = listOf(
-                DokumentInfo(
-                    dokumentInfoId = "1",
-                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                ),
-            ),
-        )
+    @Nested
+    inner class ErDigitalKanalTest {
+        @Test
+        fun `skal returnere false om kanal ikke er NAV_NO`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "IKKE_NAV_NO",
+                )
 
-        // Act
-        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
+            // Act
+            val erDigitalKanal = journalpost.erDigitalKanal()
 
-        // Assert
-        assertFalse(erDigitalSøknad)
+            // Assert
+            assertFalse(erDigitalKanal)
+        }
+
+        @Test
+        fun `skal returnere false om kanal er NAV_NO`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                )
+
+            // Act
+            val erDigitalKanal = journalpost.erDigitalKanal()
+
+            // Assert
+            assertTrue(erDigitalKanal)
+        }
     }
 
-    @Test
-    fun `skal returnere false dersom journalpost ikke inneholder noen dokumenter og tema er KON`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-            kanal = "NAV_NO",
-            dokumenter = null,
-        )
+    @Nested
+    inner class HarKontantstøtteSøknadTest {
+        @Test
+        fun `skal returnere false dokumenter er null`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter = null,
+                )
 
-        // Act
-        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
+            // Act
+            val harKontantstøtteSøknad = journalpost.harKontantstøtteSøknad()
 
-        // Assert
-        assertFalse(erDigitalSøknad)
+            // Assert
+            assertFalse(harKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dokumenter er tom`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter = emptyList(),
+                )
+
+            // Act
+            val harKontantstøtteSøknad = journalpost.harKontantstøtteSøknad()
+
+            // Assert
+            assertFalse(harKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dokumenter ikke inneholder søknad for kontatsøttte`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harKontantstøtteSøknad = journalpost.harKontantstøtteSøknad()
+
+            // Assert
+            assertFalse(harKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere true om journalpost har søknad for kontatstøtte`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harKontantstøtteSøknad = journalpost.harKontantstøtteSøknad()
+
+            // Assert
+            assertTrue(harKontantstøtteSøknad)
+        }
     }
 
-    @Test
-    fun `skal returnere false dersom journalpost ikke har kommet via digital kanal og tema er KON`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-            kanal = "SKAN_",
-            dokumenter = emptyList(),
-        )
+    @Nested
+    inner class HarBarnetrygdOrdinærSøknadTest {
+        @Test
+        fun `skal returnere false dokumenter er null`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter = null,
+                )
 
-        // Act
-        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
+            // Act
+            val harBarnetrygdOrdinærSøknad = journalpost.harBarnetrygdOrdinærSøknad()
 
-        // Assert
-        assertFalse(erDigitalSøknad)
+            // Assert
+            assertFalse(harBarnetrygdOrdinærSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dokumenter er tom`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter = emptyList(),
+                )
+
+            // Act
+            val harBarnetrygdOrdinærSøknad = journalpost.harBarnetrygdOrdinærSøknad()
+
+            // Assert
+            assertFalse(harBarnetrygdOrdinærSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dokumenter ikke inneholder søknad for ordinær barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harBarnetrygdOrdinærSøknad = journalpost.harBarnetrygdOrdinærSøknad()
+
+            // Assert
+            assertFalse(harBarnetrygdOrdinærSøknad)
+        }
+
+        @Test
+        fun `skal returnere true om journalpost har søknad for ordinær barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harBarnetrygdOrdinærSøknad = journalpost.harBarnetrygdOrdinærSøknad()
+
+            // Assert
+            assertTrue(harBarnetrygdOrdinærSøknad)
+        }
     }
 
-    @Test
-    fun `skal returnere true dersom journalpost er digital barnetrygd søknad og tema er BAR`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-            kanal = "NAV_NO",
-            dokumenter = listOf(
-                DokumentInfo(
-                    dokumentInfoId = "1",
-                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                ),
-            ),
-        )
+    @Nested
+    inner class HarBarnetrygdUtvidetSøknadTest {
+        @Test
+        fun `skal returnere false dokumenter er null`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter = null,
+                )
 
-        // Act
-        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
+            // Act
+            val harBarnetrygdUtvidetSøknad = journalpost.harBarnetrygdUtvidetSøknad()
 
-        // Assert
-        assertTrue(erDigitalSøknad)
+            // Assert
+            assertFalse(harBarnetrygdUtvidetSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dokumenter er tom`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter = emptyList(),
+                )
+
+            // Act
+            val harBarnetrygdUtvidetSøknad = journalpost.harBarnetrygdUtvidetSøknad()
+
+            // Assert
+            assertFalse(harBarnetrygdUtvidetSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dokumenter ikke inneholder søknad for utvidet barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harBarnetrygdUtvidetSøknad = journalpost.harBarnetrygdUtvidetSøknad()
+
+            // Assert
+            assertFalse(harBarnetrygdUtvidetSøknad)
+        }
+
+        @Test
+        fun `skal returnere true om journalpost har søknad for utvidet barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harBarnetrygdUtvidetSøknad = journalpost.harBarnetrygdUtvidetSøknad()
+
+            // Assert
+            assertTrue(harBarnetrygdUtvidetSøknad)
+        }
     }
 
-    @Test
-    fun `skal returnere false dersom journalpost ikke er digital barnetrygd søknad og tema er BAR`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-            kanal = "NAV_NO",
-            dokumenter = listOf(
-                DokumentInfo(
-                    dokumentInfoId = "1",
-                    brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                ),
-            ),
-        )
+    @Nested
+    inner class HarBarnetrygdSøknadTest {
+        @Test
+        fun `skal returnere false om dokumenter hver har søknad for ordinær eller utvidet barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                    ),
+                )
 
-        // Act
-        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
+            // Act
+            val harBarnetrygdSøknad = journalpost.harBarnetrygdSøknad()
 
-        // Assert
-        assertFalse(erDigitalSøknad)
+            // Assert
+            assertFalse(harBarnetrygdSøknad)
+        }
+
+        @Test
+        fun `skal returnere true om dokumenter har søknad for ordinær barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harBarnetrygdSøknad = journalpost.harBarnetrygdSøknad()
+
+            // Assert
+            assertTrue(harBarnetrygdSøknad)
+        }
+
+        @Test
+        fun `skal returnere true om dokumenter har søknad for utvidet barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harBarnetrygdSøknad = journalpost.harBarnetrygdSøknad()
+
+            // Assert
+            assertTrue(harBarnetrygdSøknad)
+        }
+
+        @Test
+        fun `skal returnere true om dokumenter har søknad for både ordinær og utvidet barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "2",
+                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harBarnetrygdSøknad = journalpost.harBarnetrygdSøknad()
+
+            // Assert
+            assertTrue(harBarnetrygdSøknad)
+        }
     }
 
-    @Test
-    fun `skal returnere false dersom journalpost ikke inneholder noen dokumenter og tema er BAR`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-            kanal = "NAV_NO",
-            dokumenter = null,
-        )
+    @Nested
+    inner class HarDigitalBarnetrygdSøknadTest {
+        @Test
+        fun `skal returnere false om det ikke er en digital søknad`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "IKKE_NAV_NO",
+                )
 
-        // Act
-        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
+            // Act
+            val harDigitalBarnetrygdSøknad = journalpost.harDigitalBarnetrygdSøknad()
 
-        // Assert
-        assertFalse(erDigitalSøknad)
+            // Assert
+            assertFalse(harDigitalBarnetrygdSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om dokumenter er null`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter = null,
+                )
+
+            // Act
+            val harDigitalBarnetrygdSøknad = journalpost.harDigitalBarnetrygdSøknad()
+
+            // Assert
+            assertFalse(harDigitalBarnetrygdSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om dokumenter er tom`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter = emptyList(),
+                )
+
+            // Act
+            val harDigitalBarnetrygdSøknad = journalpost.harDigitalBarnetrygdSøknad()
+
+            // Assert
+            assertFalse(harDigitalBarnetrygdSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om dokumenter ikke inneholder søknad for barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harDigitalBarnetrygdSøknad = journalpost.harDigitalBarnetrygdSøknad()
+
+            // Assert
+            assertFalse(harDigitalBarnetrygdSøknad)
+        }
+
+        @Test
+        fun `skal returnere true om dokumenter inneholder søknad for barnetrygd`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harDigitalBarnetrygdSøknad = journalpost.harDigitalBarnetrygdSøknad()
+
+            // Assert
+            assertTrue(harDigitalBarnetrygdSøknad)
+        }
     }
 
-    @Test
-    fun `skal returnere false dersom journalpost ikke har kommet via digital kanal og tema er BAR`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-            kanal = "SKAN_",
-            dokumenter = emptyList(),
-        )
+    @Nested
+    inner class HarDigitalKontantstøtteSøknadTest {
+        @Test
+        fun `skal returnere false om det ikke er en digital søknad`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "IKKE_NAV_NO",
+                )
 
-        // Act
-        val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
+            // Act
+            val harDigitalKontantstøtteSøknad = journalpost.harDigitalKontantstøtteSøknad()
 
-        // Assert
-        assertFalse(erDigitalSøknad)
+            // Assert
+            assertFalse(harDigitalKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om dokumenter er null`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter = null,
+                )
+
+            // Act
+            val harDigitalKontantstøtteSøknad = journalpost.harDigitalKontantstøtteSøknad()
+
+            // Assert
+            assertFalse(harDigitalKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om dokumenter er tom`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter = emptyList(),
+                )
+
+            // Act
+            val harDigitalKontantstøtteSøknad = journalpost.harDigitalKontantstøtteSøknad()
+
+            // Assert
+            assertFalse(harDigitalKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere false om dokumenter ikke inneholder søknad for kontatstøtte`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harDigitalKontantstøtteSøknad = journalpost.harDigitalKontantstøtteSøknad()
+
+            // Assert
+            assertFalse(harDigitalKontantstøtteSøknad)
+        }
+
+        @Test
+        fun `skal returnere true om dokumenter inneholder søknad for kontatstøtte`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val harDigitalKontantstøtteSøknad = journalpost.harDigitalKontantstøtteSøknad()
+
+            // Assert
+            assertTrue(harDigitalKontantstøtteSøknad)
+        }
     }
 
-    @Test
-    fun `skal kaste feil dersom tema enda ikke er støttet`() {
-        // Arrange
-        val journalpost = Journalpost(
-            journalpostId = "123",
-            journalposttype = Journalposttype.I,
-            journalstatus = Journalstatus.MOTTATT,
-        )
+    @Nested
+    inner class HarDigitalSøknadTest {
+        @Test
+        fun `skal returnere true dersom journalpost er digital kontantstøtte søknad og tema er KON`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                    ),
+                )
 
-        // Act
-        val error = assertThrows<Error> { journalpost.harDigitalSøknad(Tema.ENF) }
+            // Act
+            val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
 
-        // Assert
-        assertEquals(expected = "Støtter ikke tema ${Tema.ENF}", actual = error.message)
+            // Assert
+            assertTrue(erDigitalSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dersom journalpost ikke er digital kontantstøtte søknad og tema er KON`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
+
+            // Assert
+            assertFalse(erDigitalSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dersom journalpost ikke inneholder noen dokumenter og tema er KON`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter = null,
+                )
+
+            // Act
+            val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
+
+            // Assert
+            assertFalse(erDigitalSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dersom journalpost ikke har kommet via digital kanal og tema er KON`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "SKAN_",
+                    dokumenter = emptyList(),
+                )
+
+            // Act
+            val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.KON)
+
+            // Assert
+            assertFalse(erDigitalSøknad)
+        }
+
+        @Test
+        fun `skal returnere true dersom journalpost er digital barnetrygd søknad og tema er BAR`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
+
+            // Assert
+            assertTrue(erDigitalSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dersom journalpost ikke er digital barnetrygd søknad og tema er BAR`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        ),
+                    ),
+                )
+
+            // Act
+            val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
+
+            // Assert
+            assertFalse(erDigitalSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dersom journalpost ikke inneholder noen dokumenter og tema er BAR`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "NAV_NO",
+                    dokumenter = null,
+                )
+
+            // Act
+            val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
+
+            // Assert
+            assertFalse(erDigitalSøknad)
+        }
+
+        @Test
+        fun `skal returnere false dersom journalpost ikke har kommet via digital kanal og tema er BAR`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                    kanal = "SKAN_",
+                    dokumenter = emptyList(),
+                )
+
+            // Act
+            val erDigitalSøknad = journalpost.harDigitalSøknad(Tema.BAR)
+
+            // Assert
+            assertFalse(erDigitalSøknad)
+        }
+
+        @Test
+        fun `skal kaste feil dersom tema enda ikke er støttet`() {
+            // Arrange
+            val journalpost =
+                Journalpost(
+                    journalpostId = "123",
+                    journalposttype = Journalposttype.I,
+                    journalstatus = Journalstatus.MOTTATT,
+                )
+
+            // Act
+            val error = assertThrows<Error> { journalpost.harDigitalSøknad(Tema.ENF) }
+
+            // Assert
+            assertEquals(expected = "Støtter ikke tema ${Tema.ENF}", actual = error.message)
+        }
     }
+
+    @Nested
+    inner class HentHovedDokumentTittelTest {
+        @Test
+        fun `skal kaste exception om dokumenter er null`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter = null,
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<IllegalStateException> {
+                    journalpost.hentHovedDokumentTittel()
+                }
+            assertEquals(exception.message, "Journalpost ${journalpost.journalpostId} mangler dokumenter")
+        }
+
+        @Test
+        fun `skal kaste exception om dokumenter er tom`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter = emptyList(),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<IllegalStateException> {
+                    journalpost.hentHovedDokumentTittel()
+                }
+            assertEquals(exception.message, "Journalpost ${journalpost.journalpostId} mangler dokumenter")
+        }
+
+        @Test
+        fun `skal returnere null om brevkode er null`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = null,
+                        ),
+                    ),
+                )
+
+            // Act
+            val hovedDokumentTittel = journalpost.hentHovedDokumentTittel()
+
+            // Assert
+            assertNull(hovedDokumentTittel)
+        }
+
+        @Test
+        fun `skal returnere null om tittel er null for dokumentinfo`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = null,
+                            tittel = "AAA",
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "2",
+                            brevkode = "2",
+                            tittel = null,
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "3",
+                            brevkode = "1",
+                            tittel = "CCC",
+                        ),
+                    ),
+                )
+
+            // Act
+            val hovedDokumentTittel = journalpost.hentHovedDokumentTittel()
+
+            // Assert
+            assertNull(hovedDokumentTittel)
+        }
+
+        @Test
+        fun `skal returnere hoved dokument tittel`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = null,
+                            tittel = "AAA",
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "2",
+                            brevkode = "2",
+                            tittel = "BBB",
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "3",
+                            brevkode = "1",
+                            tittel = "CCC",
+                        ),
+                    ),
+                )
+
+            // Act
+            val hovedDokumentTittel = journalpost.hentHovedDokumentTittel()
+
+            // Assert
+            assertEquals(hovedDokumentTittel, "BBB")
+        }
+    }
+
+    private fun lagJournalpost(
+        journalpostId: String = "123",
+        journalposttype: Journalposttype = Journalposttype.I,
+        journalstatus: Journalstatus = Journalstatus.MOTTATT,
+        kanal: String = "NAV_NO",
+        dokumenter: List<DokumentInfo>? = null,
+        relevanteDatoer: List<RelevantDato>? = null,
+    ) = Journalpost(
+        journalpostId = journalpostId,
+        journalposttype = journalposttype,
+        journalstatus = journalstatus,
+        kanal = kanal,
+        dokumenter = dokumenter,
+        relevanteDatoer = relevanteDatoer,
+    )
 }


### PR DESCRIPTION
Tenkte det var greit å rydde opp i noen metoder som hadde misvisende navn, samt skrive enhetstester for metoder som manglet det. 

Endret fra `erDigitalKontantstøtteSøknad` til `erBarnetrygdSøknad` i `DokumentInfo` klassen
Endret fra `erDigitalBarnetrygdSøknad` til `erBarnetrygdSøknad` i `DokumentInfo` klassen
Endret fra `erDigitalSøknad` til `erSøknadForTema` i `DokumentInfo`  klassen

Tok i bruk metodene `erKontantstøtteSøknad`, `erBarnetrygdOrdinærSøknad`, og `erBarnetrygdUtvidetSøknad` i `Journalpost` klassen, tidligere brukte man brevkoden rått
