### PR TITLE
NAV-23617: Fikser SerDes for KS-søknad

### DIFF
--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknadDeserializerTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknadDeserializerTest.kt
@@ -231,16 +231,16 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             utenlandsperioder = emptyList(),
@@ -262,16 +262,16 @@ class VersjonertBarnetrygdSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             utenlandsperioder = emptyList(),
             arbeidsperioderUtland = emptyList(),

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
@@ -309,9 +309,9 @@ class DokumentInfoTest {
                     dokumentInfoId = "1",
                     brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                     dokumentvarianter =
-                        listOf(
-                            Dokumentvariant(Dokumentvariantformat.ORIGINAL, "Testfil", false),
-                        ),
+                    listOf(
+                        Dokumentvariant(Dokumentvariantformat.ORIGINAL, "Testfil", false),
+                    ),
                 )
 
             // Act
@@ -329,9 +329,9 @@ class DokumentInfoTest {
                     dokumentInfoId = "1",
                     brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                     dokumentvarianter =
-                        listOf(
-                            Dokumentvariant(Dokumentvariantformat.ARKIV, "Testfil", false),
-                        ),
+                    listOf(
+                        Dokumentvariant(Dokumentvariantformat.ARKIV, "Testfil", false),
+                    ),
                 )
 
             // Act

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v1/KontantstøtteSøknad.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v1/KontantstøtteSøknad.kt
@@ -98,13 +98,13 @@ data class Barn(
 typealias Locale = String
 
 class TekstPåSpråkMap(
-    val tekstPåSpråk: Map<String, String>,
-) : Map<String, String> by tekstPåSpråk {
+    val tekstPåSpråk: Map<Locale, String>,
+) : Map<Locale, String> by tekstPåSpråk {
     @JsonCreator
-    fun fromJson(tekstPåSpråk: Map<String, String>): TekstPåSpråkMap = TekstPåSpråkMap(tekstPåSpråk)
+    fun fromJson(tekstPåSpråk: Map<Locale, String>): TekstPåSpråkMap = TekstPåSpråkMap(tekstPåSpråk)
 
     @JsonValue
-    fun toJson(): Map<String, String> = tekstPåSpråk
+    fun toJson(): Map<Locale, String> = tekstPåSpråk
 }
 
 enum class Dokumentasjonsbehov {

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v1/KontantstøtteSøknad.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v1/KontantstøtteSøknad.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.kontrakter.ks.søknad.v1
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
 import no.nav.familie.kontrakter.felles.søknad.BaksSøknadBase
 import no.nav.familie.kontrakter.felles.søknad.BaksSøknadPersonBase
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
@@ -96,8 +98,14 @@ data class Barn(
 typealias Locale = String
 
 class TekstPåSpråkMap(
-    tekstPåSpråk: Map<Locale, String>,
-) : HashMap<Locale, String>(tekstPåSpråk)
+    val tekstPåSpråk: Map<String, String>,
+) : Map<String, String> by tekstPåSpråk {
+    @JsonCreator
+    fun fromJson(tekstPåSpråk: Map<String, String>): TekstPåSpråkMap = TekstPåSpråkMap(tekstPåSpråk)
+
+    @JsonValue
+    fun toJson(): Map<String, String> = tekstPåSpråk
+}
 
 enum class Dokumentasjonsbehov {
     AVTALE_DELT_BOSTED,

--- a/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknadDeserializerTest.kt
+++ b/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknadDeserializerTest.kt
@@ -41,9 +41,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
                 teksterTilPdf =
-                    mapOf(
-                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-                    ),
+                mapOf(
+                    "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                ),
                 originalSpråk = "NB",
                 finnesPersonMedAdressebeskyttelse = false,
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
@@ -81,9 +81,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
                 teksterTilPdf =
-                    mapOf(
-                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-                    ),
+                mapOf(
+                    "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                ),
                 originalSpråk = "NB",
                 finnesPersonMedAdressebeskyttelse = false,
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
@@ -121,9 +121,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
                 teksterTilPdf =
-                    mapOf(
-                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-                    ),
+                mapOf(
+                    "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -160,9 +160,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
                 teksterTilPdf =
-                    mapOf(
-                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-                    ),
+                mapOf(
+                    "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -199,9 +199,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
                 teksterTilPdf =
-                    mapOf(
-                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-                    ),
+                mapOf(
+                    "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -238,9 +238,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
                 teksterTilPdf =
-                    mapOf(
-                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-                    ),
+                mapOf(
+                    "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -277,9 +277,9 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
                 teksterTilPdf =
-                    mapOf(
-                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-                    ),
+                mapOf(
+                    "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -344,16 +344,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,
@@ -384,16 +384,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,
@@ -423,16 +423,16 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
             navn = lagStringSøknadsfelt("Navn"),
             statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
             adresse =
-                lagStringSøknadsfelt(
-                    SøknadAdresse(
-                        adressenavn = "Gate",
-                        postnummer = null,
-                        husbokstav = null,
-                        bruksenhetsnummer = null,
-                        husnummer = null,
-                        poststed = null,
-                    ),
+            lagStringSøknadsfelt(
+                SøknadAdresse(
+                    adressenavn = "Gate",
+                    postnummer = null,
+                    husbokstav = null,
+                    bruksenhetsnummer = null,
+                    husnummer = null,
+                    poststed = null,
                 ),
+            ),
             adressebeskyttelse = false,
             sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
             borPåRegistrertAdresse = null,

--- a/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknadDeserializerTest.kt
+++ b/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/VersjonertKontantstøtteSøknadDeserializerTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.kontrakter.felles.søknad.UnsupportedVersionException
 import no.nav.familie.kontrakter.ks.søknad.v1.RegistrertBostedType
 import no.nav.familie.kontrakter.ks.søknad.v1.SIVILSTANDTYPE
 import no.nav.familie.kontrakter.ks.søknad.v1.SøknadAdresse
+import no.nav.familie.kontrakter.ks.søknad.v1.TekstPåSpråkMap
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -39,7 +40,10 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 barn = listOf(lagBarnV4(barnFnr)),
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
-                teksterTilPdf = emptyMap(),
+                teksterTilPdf =
+                    mapOf(
+                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                    ),
                 originalSpråk = "NB",
                 finnesPersonMedAdressebeskyttelse = false,
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
@@ -76,7 +80,10 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 barn = listOf(lagBarnV4(barnFnr)),
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
-                teksterTilPdf = emptyMap(),
+                teksterTilPdf =
+                    mapOf(
+                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                    ),
                 originalSpråk = "NB",
                 finnesPersonMedAdressebeskyttelse = false,
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
@@ -113,7 +120,10 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 barn = listOf(lagBarnV4(barnFnr)),
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
-                teksterTilPdf = emptyMap(),
+                teksterTilPdf =
+                    mapOf(
+                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                    ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -149,7 +159,10 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 barn = listOf(lagBarnV4(barnFnr)),
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
-                teksterTilPdf = emptyMap(),
+                teksterTilPdf =
+                    mapOf(
+                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                    ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -185,7 +198,10 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 barn = listOf(lagBarnV3(barnFnr)),
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
-                teksterTilPdf = emptyMap(),
+                teksterTilPdf =
+                    mapOf(
+                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                    ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -221,7 +237,10 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 barn = listOf(lagBarnV2(barnFnr)),
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
-                teksterTilPdf = emptyMap(),
+                teksterTilPdf =
+                    mapOf(
+                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                    ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -257,7 +276,10 @@ class VersjonertKontantstøtteSøknadDeserializerTest {
                 barn = listOf(lagBarnV1(barnFnr)),
                 antallEøsSteg = 0,
                 dokumentasjon = emptyList(),
-                teksterTilPdf = emptyMap(),
+                teksterTilPdf =
+                    mapOf(
+                        "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+                    ),
                 originalSpråk = "NB",
                 erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
                 søktAsylForBarn = lagStringSøknadsfelt("Nei"),


### PR DESCRIPTION
[NAV-23617](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23617)

Klassen `TekstPåSpråkMap` var ikke lenger kompatibel med versjonen av jackson som blir brukt i spring boot 3.4.0. Justerer derfor implementasjonen av `TekstPåSpråkMap` slik at serialisering og deserialisering fungerer slik det skal igjen.