### PR TITLE
Endre rekkefølge pa stønadsstart

### DIFF
--- a/enslig-forsorger-test/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/TestsøknadBuilder.kt
+++ b/enslig-forsorger-test/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/TestsøknadBuilder.kt
@@ -338,9 +338,9 @@ class TestsøknadBuilder private constructor(
 
         fun setStønadstart(month: Month = Month.AUGUST, fraÅr: Int = 2018, søkerFraBestemtMåned: Boolean = true): Builder {
             this.stønadsstart = Stønadsstart(
+                Søknadsfelt("Søker du stønad fra et bestemt tidspunkt", søkerFraBestemtMåned),
                 Søknadsfelt("Fra måned", month),
                 Søknadsfelt("Fra år", fraÅr),
-                Søknadsfelt("Søker du stønad fra et bestemt tidspunkt", søkerFraBestemtMåned),
             )
 
             return this

--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/Stønadsstart.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/Stønadsstart.kt
@@ -3,7 +3,7 @@ package no.nav.familie.kontrakter.ef.søknad
 import java.time.Month
 
 data class Stønadsstart(
+    val søkerFraBestemtMåned: Søknadsfelt<Boolean>,
     val fraMåned: Søknadsfelt<Month>?,
     val fraÅr: Søknadsfelt<Int>?,
-    val søkerFraBestemtMåned: Søknadsfelt<Boolean>,
 )


### PR DESCRIPTION
Endret rekkefølgen på stønadsstart, slik at "Søker du fra bestemt måned" kommer før eventuell måned og år bruker velger dersom svaret er "ja".