### PR TITLE
Legger til funksjon for å mappe `Fagsystem` i klage-pakke til `Fagsystem` i felles-pakke

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/Fagsystem.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/Fagsystem.kt
@@ -8,7 +8,7 @@ enum class Fagsystem {
     KS,
     ;
 
-    fun tilFagsaksystem(): Fagsystem =
+    fun tilFellesFagsystem(): Fagsystem =
         when (this) {
             EF -> Fagsystem.EF
             BA -> Fagsystem.BA

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/Fagsystem.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/klage/Fagsystem.kt
@@ -1,7 +1,17 @@
 package no.nav.familie.kontrakter.felles.klage
 
+import no.nav.familie.kontrakter.felles.Fagsystem
+
 enum class Fagsystem {
     EF,
     BA,
     KS,
+    ;
+
+    fun tilFagsaksystem(): Fagsystem =
+        when (this) {
+            EF -> Fagsystem.EF
+            BA -> Fagsystem.BA
+            KS -> Fagsystem.KONT
+        }
 }


### PR DESCRIPTION
Favro: [NAV-23745](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23745)

Ved oversendelse av `OversendtKlageAnkeV3` bruker vi idag `Fagsystem` fra klage-pakke for feltene `fagsystem` og `kilde`. Dette fungerer fint for EF og BA, men for KS fungerer ikke dette. For kontantstøtte forventer `kabal-api` verdien `KONT` i begge disse feltene og ikke `KS`. 

I og med at vi bruker `KS` om fagsystemet internt mellom teamfamilie-applikasjonene legger jeg her til mulighet til å mappe `Fagsystem` i klage-pakke til `Fagsystem` i felles-pakke. Det er `Fagsystem` i felles-pakke som blir brukt ved opprettelse av Journalposter blandt annet, og kabal har basert seg på verdiene i `Fagsaksystem` i dokarkiv når det gjelder hva de forventer av verdier i feltene `kilde` og `fagsystem`.