### PR TITLE
Introduserer SistInnsendtSøknadDto klasse for kontrakter

### DIFF
--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/BarnetrygdSøknadDataGenerator.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/BarnetrygdSøknadDataGenerator.kt
@@ -75,16 +75,16 @@ fun lagSøkerV8(fnr: String): SøkerV8 =
         navn = lagStringSøknadsfelt("Navn"),
         statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
         adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
-                ),
+        lagStringSøknadsfelt(
+            SøknadAdresse(
+                adressenavn = "Gate",
+                postnummer = null,
+                husbokstav = null,
+                bruksenhetsnummer = null,
+                husnummer = null,
+                poststed = null,
             ),
+        ),
         adressebeskyttelse = false,
         sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
         utenlandsperioder = emptyList(),
@@ -106,16 +106,16 @@ fun lagSøkerV7(fnr: String): SøkerV7 =
         navn = lagStringSøknadsfelt("Navn"),
         statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
         adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
-                ),
+        lagStringSøknadsfelt(
+            SøknadAdresse(
+                adressenavn = "Gate",
+                postnummer = null,
+                husbokstav = null,
+                bruksenhetsnummer = null,
+                husnummer = null,
+                poststed = null,
             ),
+        ),
         sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
         utenlandsperioder = emptyList(),
         arbeidsperioderUtland = emptyList(),

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/søknad/SistInnsendtSøknadDto.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/søknad/SistInnsendtSøknadDto.kt
@@ -1,0 +1,16 @@
+package no.nav.familie.kontrakter.felles.søknad
+
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+data class SistInnsendtSøknadDto(
+    val søknadsdato: LocalDate,
+    val stønadType: StønadType,
+)
+
+fun SistInnsendtSøknadDto.nyereEnn(dager: Long = 30): Boolean {
+    val dagensDato = LocalDate.now()
+    val dagerSidenInnsending = ChronoUnit.DAYS.between(søknadsdato, dagensDato)
+    return dagerSidenInnsending <= dager
+}

--- a/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/KontantstøtteSøknadDataGenerator.kt
+++ b/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/KontantstøtteSøknadDataGenerator.kt
@@ -24,9 +24,9 @@ fun lagKontantstøtteSøknadV5(
         antallEøsSteg = 0,
         dokumentasjon = emptyList(),
         teksterTilPdf =
-            mapOf(
-                "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-            ),
+        mapOf(
+            "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+        ),
         originalSpråk = "NB",
         finnesPersonMedAdressebeskyttelse = false,
         erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
@@ -50,9 +50,9 @@ fun lagKontantstøtteSøknadV4(
         antallEøsSteg = 0,
         dokumentasjon = emptyList(),
         teksterTilPdf =
-            mapOf(
-                "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-            ),
+        mapOf(
+            "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+        ),
         originalSpråk = "NB",
         erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
         søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -75,9 +75,9 @@ fun lagKontantstøtteSøknadV3(
         antallEøsSteg = 0,
         dokumentasjon = emptyList(),
         teksterTilPdf =
-            mapOf(
-                "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-            ),
+        mapOf(
+            "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+        ),
         originalSpråk = "NB",
         erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
         søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -100,9 +100,9 @@ fun lagKontantstøtteSøknadV2(
         antallEøsSteg = 0,
         dokumentasjon = emptyList(),
         teksterTilPdf =
-            mapOf(
-                "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-            ),
+        mapOf(
+            "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+        ),
         originalSpråk = "NB",
         erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
         søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -125,9 +125,9 @@ fun lagKontantstøtteSøknadV1(
         antallEøsSteg = 0,
         dokumentasjon = emptyList(),
         teksterTilPdf =
-            mapOf(
-                "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
-            ),
+        mapOf(
+            "testApiNavn" to TekstPåSpråkMap(mapOf("nb" to "bokmål", "nn" to "nynorsk", "en" to "engelsk")),
+        ),
         originalSpråk = "NB",
         erNoenAvBarnaFosterbarn = lagStringSøknadsfelt("Nei"),
         søktAsylForBarn = lagStringSøknadsfelt("Nei"),
@@ -152,16 +152,16 @@ fun lagSøkerV4(fnr: String): Søker =
         navn = lagStringSøknadsfelt("Navn"),
         statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
         adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
-                ),
+        lagStringSøknadsfelt(
+            SøknadAdresse(
+                adressenavn = "Gate",
+                postnummer = null,
+                husbokstav = null,
+                bruksenhetsnummer = null,
+                husnummer = null,
+                poststed = null,
             ),
+        ),
         adressebeskyttelse = false,
         sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
         borPåRegistrertAdresse = null,
@@ -192,16 +192,16 @@ fun lagSøkerV2(fnr: String): no.nav.familie.kontrakter.ks.søknad.v2.Søker =
         navn = lagStringSøknadsfelt("Navn"),
         statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
         adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
-                ),
+        lagStringSøknadsfelt(
+            SøknadAdresse(
+                adressenavn = "Gate",
+                postnummer = null,
+                husbokstav = null,
+                bruksenhetsnummer = null,
+                husnummer = null,
+                poststed = null,
             ),
+        ),
         adressebeskyttelse = false,
         sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
         borPåRegistrertAdresse = null,
@@ -231,16 +231,16 @@ fun lagSøkerV1(fnr: String): no.nav.familie.kontrakter.ks.søknad.v1.Søker =
         navn = lagStringSøknadsfelt("Navn"),
         statsborgerskap = lagStringSøknadsfelt(listOf("Norge")),
         adresse =
-            lagStringSøknadsfelt(
-                SøknadAdresse(
-                    adressenavn = "Gate",
-                    postnummer = null,
-                    husbokstav = null,
-                    bruksenhetsnummer = null,
-                    husnummer = null,
-                    poststed = null,
-                ),
+        lagStringSøknadsfelt(
+            SøknadAdresse(
+                adressenavn = "Gate",
+                postnummer = null,
+                husbokstav = null,
+                bruksenhetsnummer = null,
+                husnummer = null,
+                poststed = null,
             ),
+        ),
         adressebeskyttelse = false,
         sivilstand = lagStringSøknadsfelt(SIVILSTANDTYPE.UOPPGITT),
         borPåRegistrertAdresse = null,


### PR DESCRIPTION
# Introduserer SistInnsendtSøknadDto klasse for kontrakter

### Hvorfor er denne endringen nødvendig? ✨ 

Vi ønsker å presentere et lett objekt som inneholder informasjon om den sist innsendte søknaden for brukter, per stønad. Dette objektet har som mål å fungere som oppslag og kan eksempelvis trekkes frem helt til front-end. Det planlagte usecase for dette objektet er å trekke det frem helt til starten av søknadsflyten, der vi nå kan sjekke om bruker allerede har sendt en søknad av den typen, samt når den siste søknaden ble innsendt. 

### Verdt å nevne

* Det foregår arbeid i både `ef-mottak` og `ef-sak-soknad-api` som vil ta i bruk dette objektet. Akkurat nå er det en mismatch i begge repoene, der vi håper at denne PRen vil rette opp i dette. 
* Kommer med en snedig extension som lar oss sjekke om det har gått antall dager siden innsending. 
* Endrer også til `stønadType` av typen `StønadType` der vi planlegger å mappe om i de tilfellene vi trenger. Dette er tilbakemelding og ønske fra @charliemidtlyng. 