### PR TITLE
NAV-24445: La til behandlingstype klage

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgaveRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgaveRequest.kt
@@ -51,6 +51,7 @@ enum class Behandlingstype(val value: String) {
     NASJONAL("ae0118"),
     EØS("ae0120"),
     Tilbakekreving("ae0161"),
+    Klage("ae0058"),
 }
 
 enum class OppgavePrioritet {


### PR DESCRIPTION
Favro: [NAV-24445](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24445)

Etter nærmere diskusjon har vi kommet fram til at vi vil sende `behandlingstema` = `null` og `behandlingstype` = `ae0058` (Klage) når vi oppretter oppgaver [her](https://github.com/navikt/familie-klage/blob/main/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt#L115-L121).  I tilleg har vi lyst til å sette de samme verdiene når vi mottar et dokument i baks-mottak [her](https://github.com/navikt/familie-baks-mottak/blob/main/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt#L23-L35) og [her](https://github.com/navikt/familie-baks-mottak/blob/main/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt#L39-L50) for BA og tilsvarende [her](https://github.com/navikt/familie-baks-mottak/blob/main/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/Kontantst%C3%B8tteOppgaveMapper.kt#L22) og [her](https://github.com/navikt/familie-baks-mottak/blob/main/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/Kontantst%C3%B8tteOppgaveMapper.kt#L28-L39) for KS. 

Legger til `behandlingstype` klage `ae0058` i familie-kontrakter slik at det kan tas i bruk i disse applikasjonene. 

Har slått opp `behandlingstype` i kodeverksklienten og `ae0058` er en gyldig verdi der. Den brukes også andre steder i NAV, se [her](https://github.com/search?q=org%3Anavikt%20ae0058&type=code).

OBS! `Behandlingstema.KLAGE` har også verdi `ae0058` som vist [her](https://github.com/navikt/familie-kontrakter/blob/main/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Behandlingstema.kt#L18), men jeg finner ikke den verdien i kodeverksklienten under `behandlingstema` så jeg antar at den er lagt inn feil. Det burde man rydde opp senere. Har laget et favro-kort på det [her](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24542). 
