### PR TITLE
NAV-24505: La til metoder for klage på journalpost

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Brevkoder.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Brevkoder.kt
@@ -3,7 +3,15 @@ package no.nav.familie.kontrakter.felles
 object Brevkoder {
     const val BARNETRYGD_ORDINÆR_SØKNAD = "NAV 33-00.07"
     const val BARNETRYGD_UTVIDET_SØKNAD = "NAV 33-00.09"
+
     const val KONTANTSTØTTE_SØKNAD = "NAV 34-00.08"
 
+    const val KLAGE_ANKE = "NAV 90-00.08"
+    const val KLAGE = "NAV 90-00.08 K"
+    const val ETTERSENDELSE_TIL_KLAGE_ANKE = "NAVe 90-00.08"
+    const val ETTERSENDELSE_TIL_KLAGE = "NAVe 90-00.08 K"
+
     val BARNETRYGD_BREVKODER = listOf(BARNETRYGD_ORDINÆR_SØKNAD, BARNETRYGD_UTVIDET_SØKNAD)
+
+    val KLAGE_BREVKODER = setOf(KLAGE_ANKE, KLAGE, ETTERSENDELSE_TIL_KLAGE_ANKE, ETTERSENDELSE_TIL_KLAGE)
 }

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfo.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfo.kt
@@ -26,5 +26,7 @@ data class DokumentInfo(
             else -> throw Error("Støtter ikke tema $tema")
         }
 
+    fun erKlage() = Brevkoder.KLAGE_BREVKODER.any { brevkode -> brevkode == this.brevkode }
+
     fun harOriginalVariant(): Boolean = this.dokumentvarianter?.any { it.variantformat == Dokumentvariantformat.ORIGINAL } ?: false
 }

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/Journalpost.kt
@@ -42,6 +42,10 @@ data class Journalpost(
             else -> throw Error("Støtter ikke tema $tema")
         }
 
+    fun harKlage() = dokumenter?.any { it -> it.erKlage() } ?: false
+
+    fun harDigitalKlage() = erDigitalKanal() && harKlage()
+
     fun hentHovedDokumentTittel(): String? {
         if (dokumenter.isNullOrEmpty()) error("Journalpost $journalpostId mangler dokumenter")
         return dokumenter.firstOrNull { it.brevkode != null }?.tittel

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
@@ -300,6 +300,89 @@ class DokumentInfoTest {
     }
 
     @Nested
+    inner class ErKlageTest {
+        @Test
+        fun `skal returnere true for brevkode klage`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.KLAGE,
+                )
+
+            // Act
+            val erKlage = dokumentInfo.erKlage()
+
+            // Assert
+            assertTrue(erKlage)
+        }
+
+        @Test
+        fun `skal returnere true for brevkode klage anke`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.KLAGE_ANKE,
+                )
+
+            // Act
+            val erKlage = dokumentInfo.erKlage()
+
+            // Assert
+            assertTrue(erKlage)
+        }
+
+        @Test
+        fun `skal returnere true for brevkode ettersendelse til klage`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.ETTERSENDELSE_TIL_KLAGE,
+                )
+
+            // Act
+            val erKlage = dokumentInfo.erKlage()
+
+            // Assert
+            assertTrue(erKlage)
+        }
+
+        @Test
+        fun `skal returnere true for brevkode ettersendelse til klage anke`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.ETTERSENDELSE_TIL_KLAGE_ANKE,
+                )
+
+            // Act
+            val erKlage = dokumentInfo.erKlage()
+
+            // Assert
+            assertTrue(erKlage)
+        }
+
+        @Test
+        fun `skal returnere false for brevkode som ikke er relatert til klage`() {
+            // Arrange
+            val dokumentInfo =
+                DokumentInfo(
+                    dokumentInfoId = "1",
+                    brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                )
+
+            // Act
+            val erKlage = dokumentInfo.erKlage()
+
+            // Assert
+            assertFalse(erKlage)
+        }
+    }
+
+    @Nested
     inner class HarOriginalVariant {
         @Test
         fun `skal returnere true dersom dokumentvarianter inneholder original variant`() {
@@ -309,9 +392,9 @@ class DokumentInfoTest {
                     dokumentInfoId = "1",
                     brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                     dokumentvarianter =
-                    listOf(
-                        Dokumentvariant(Dokumentvariantformat.ORIGINAL, "Testfil", false),
-                    ),
+                        listOf(
+                            Dokumentvariant(Dokumentvariantformat.ORIGINAL, "Testfil", false),
+                        ),
                 )
 
             // Act
@@ -329,9 +412,9 @@ class DokumentInfoTest {
                     dokumentInfoId = "1",
                     brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                     dokumentvarianter =
-                    listOf(
-                        Dokumentvariant(Dokumentvariantformat.ARKIV, "Testfil", false),
-                    ),
+                        listOf(
+                            Dokumentvariant(Dokumentvariantformat.ARKIV, "Testfil", false),
+                        ),
                 )
 
             // Act

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
@@ -35,12 +35,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     relevanteDatoer =
-                    listOf(
-                        RelevantDato(
-                            dato = LocalDateTime.of(2024, 8, 1, 12, 0),
-                            datotype = "FEIL_DATOTYPE",
+                        listOf(
+                            RelevantDato(
+                                dato = LocalDateTime.of(2024, 8, 1, 12, 0),
+                                datotype = "FEIL_DATOTYPE",
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -58,12 +58,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     relevanteDatoer =
-                    listOf(
-                        RelevantDato(
-                            dato = enDato,
-                            datotype = "DATO_REGISTRERT",
+                        listOf(
+                            RelevantDato(
+                                dato = enDato,
+                                datotype = "DATO_REGISTRERT",
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -145,12 +145,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -166,12 +166,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -220,12 +220,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -241,12 +241,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -295,12 +295,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -316,12 +316,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -340,12 +340,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -361,12 +361,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -382,12 +382,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -403,16 +403,16 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                            ),
+                            DokumentInfo(
+                                dokumentInfoId = "2",
+                                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                            ),
                         ),
-                        DokumentInfo(
-                            dokumentInfoId = "2",
-                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
-                        ),
-                    ),
                 )
 
             // Act
@@ -479,12 +479,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -501,12 +501,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -573,12 +573,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -595,12 +595,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -623,12 +623,12 @@ class JournalpostTest {
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -648,12 +648,12 @@ class JournalpostTest {
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -711,12 +711,12 @@ class JournalpostTest {
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -736,12 +736,12 @@ class JournalpostTest {
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -808,6 +808,168 @@ class JournalpostTest {
     }
 
     @Nested
+    inner class HarKlageTest {
+        @Test
+        fun `skal returnere false om dokumenter er null`() {
+            // Arrange
+            val journalpost = lagJournalpost(dokumenter = null)
+
+            // Act
+            val harKlage = journalpost.harKlage()
+
+            // assert
+            assertFalse(harKlage)
+        }
+
+        @Test
+        fun `skal returnere false om dokumenter er tom`() {
+            // Arrange
+            val journalpost = lagJournalpost(dokumenter = emptyList())
+
+            // Act
+            val harKlage = journalpost.harKlage()
+
+            // assert
+            assertFalse(harKlage)
+        }
+
+        @Test
+        fun `skal returnere true om det finnes et dokument med brevkode klage`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
+                        ),
+                )
+
+            // Act
+            val harKlage = journalpost.harKlage()
+
+            // assert
+            assertTrue(harKlage)
+        }
+
+        @Test
+        fun `skal returnere false om det ikke finnes et dokument med brevkode klage`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
+                        ),
+                )
+
+            // Act
+            val harKlage = journalpost.harKlage()
+
+            // assert
+            assertFalse(harKlage)
+        }
+    }
+
+    @Nested
+    inner class HarDigitalKlageTest {
+        @Test
+        fun `skal returnere false om dokumenter er null`() {
+            // Arrange
+            val journalpost = lagJournalpost(dokumenter = null, kanal = "NAV_NO")
+
+            // Act
+            val harKlage = journalpost.harDigitalKlage()
+
+            // assert
+            assertFalse(harKlage)
+        }
+
+        @Test
+        fun `skal returnere false om dokumenter er tom`() {
+            // Arrange
+            val journalpost = lagJournalpost(dokumenter = emptyList(), kanal = "NAV_NO")
+
+            // Act
+            val harKlage = journalpost.harDigitalKlage()
+
+            // assert
+            assertFalse(harKlage)
+        }
+
+        @Test
+        fun `skal returnere true om det finnes et dokument med brevkode klage og kanal er NAV_NO`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
+                        ),
+                )
+
+            // Act
+            val harKlage = journalpost.harDigitalKlage()
+
+            // assert
+            assertTrue(harKlage)
+        }
+
+        @Test
+        fun `skal returnere false om det finnes et dokument med brevkode klage men kanal er ikke NAV_NO`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "IKKE_NAV_NO",
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.KLAGE,
+                            ),
+                        ),
+                )
+
+            // Act
+            val harKlage = journalpost.harDigitalKlage()
+
+            // assert
+            assertFalse(harKlage)
+        }
+
+        @Test
+        fun `skal returnere false om det ikke finnes et dokument med brevkode klage og kanal er NAV_NO`() {
+            // Arrange
+            val journalpost =
+                lagJournalpost(
+                    kanal = "NAV_NO",
+                    dokumenter =
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
+                            ),
+                        ),
+                )
+
+            // Act
+            val harKlage = journalpost.harDigitalKlage()
+
+            // assert
+            assertFalse(harKlage)
+        }
+    }
+
+    @Nested
     inner class HentHovedDokumentTittelTest {
         @Test
         fun `skal kaste exception om dokumenter er null`() {
@@ -847,12 +1009,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = null,
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = null,
+                            ),
                         ),
-                    ),
                 )
 
             // Act
@@ -868,23 +1030,23 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = null,
-                            tittel = "AAA",
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = null,
+                                tittel = "AAA",
+                            ),
+                            DokumentInfo(
+                                dokumentInfoId = "2",
+                                brevkode = "2",
+                                tittel = null,
+                            ),
+                            DokumentInfo(
+                                dokumentInfoId = "3",
+                                brevkode = "1",
+                                tittel = "CCC",
+                            ),
                         ),
-                        DokumentInfo(
-                            dokumentInfoId = "2",
-                            brevkode = "2",
-                            tittel = null,
-                        ),
-                        DokumentInfo(
-                            dokumentInfoId = "3",
-                            brevkode = "1",
-                            tittel = "CCC",
-                        ),
-                    ),
                 )
 
             // Act
@@ -900,23 +1062,23 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                    listOf(
-                        DokumentInfo(
-                            dokumentInfoId = "1",
-                            brevkode = null,
-                            tittel = "AAA",
+                        listOf(
+                            DokumentInfo(
+                                dokumentInfoId = "1",
+                                brevkode = null,
+                                tittel = "AAA",
+                            ),
+                            DokumentInfo(
+                                dokumentInfoId = "2",
+                                brevkode = "2",
+                                tittel = "BBB",
+                            ),
+                            DokumentInfo(
+                                dokumentInfoId = "3",
+                                brevkode = "1",
+                                tittel = "CCC",
+                            ),
                         ),
-                        DokumentInfo(
-                            dokumentInfoId = "2",
-                            brevkode = "2",
-                            tittel = "BBB",
-                        ),
-                        DokumentInfo(
-                            dokumentInfoId = "3",
-                            brevkode = "1",
-                            tittel = "CCC",
-                        ),
-                    ),
                 )
 
             // Act


### PR DESCRIPTION
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Legger til metode for å utlede hvorvidt det er klagedokumenter. 

Vi lyst til å sette `behandlingstema` = `null` og `behandlingstype` = `Behandlingstype.KLAGE` når vi mottar et dokument i baks-mottak [her](https://github.com/navikt/familie-baks-mottak/blob/main/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt#L23-L35) og [her](https://github.com/navikt/familie-baks-mottak/blob/main/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/BarnetrygdOppgaveMapper.kt#L39-L50) for BA og tilsvarende [her](https://github.com/navikt/familie-baks-mottak/blob/main/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/Kontantst%C3%B8tteOppgaveMapper.kt#L22) og [her](https://github.com/navikt/familie-baks-mottak/blob/main/src/main/kotlin/no/nav/familie/baks/mottak/integrasjoner/Kontantst%C3%B8tteOppgaveMapper.kt#L28-L39) for KS. For å gjøre dette trenger vi å vite at det vi mottar er en klage, og dermed må vi ta i bruk disse metodene. 
