### PR TITLE
Legger til feltet adressebeskyttelsegradering i Tilgang

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilgangskontroll/Tilgang.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilgangskontroll/Tilgang.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.kontrakter.felles.tilgangskontroll
 
+import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
+
 /**
  * @param personIdent er identen på den personen man har sjekket tilgang på
  * I de tilfeller der man sender en ident for å sjekker tilgang på personMedRelasjoner,
@@ -8,5 +10,6 @@ package no.nav.familie.kontrakter.felles.tilgangskontroll
 data class Tilgang(
     val personIdent: String,
     val harTilgang: Boolean,
+    val adressebeskyttelsegradering: ADRESSEBESKYTTELSEGRADERING? = null,
     val begrunnelse: String? = null,
 )


### PR DESCRIPTION
Vi ønsker å gi saksbehandler en bedre forklaring på hvorfor de ikke har tilgang til en bestemt fagsak. Legger derfor til feltet `adressebeskyttelsegradering` i `Tilgang`, slik at vi kan bruke denne til å lage en mer beskrivende feilmelding i saksbehandlingsløsningene.