### PR TITLE
Justerer TilgangsstyrtJournalpost

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/TilgangsstyrtJournalpost.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/journalpost/TilgangsstyrtJournalpost.kt
@@ -2,5 +2,10 @@ package no.nav.familie.kontrakter.felles.journalpost
 
 data class TilgangsstyrtJournalpost(
     val journalpost: Journalpost,
+    val journalpostTilgang: JournalpostTilgang,
+)
+
+data class JournalpostTilgang(
     val harTilgang: Boolean,
+    val begrunnelse: String? = null,
 )


### PR DESCRIPTION
Favro: [NAV-22989](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22989)

Utvider `TilgangsstyrtJournalpost` med mer informasjon om hvorfor saksbehandler ikke får tilgang til en journalpost.