### PR TITLE
skal kunne utlede saksbehandler sin enhet i klartekst. Skal brukes un…

### DIFF
--- a/enslig-forsorger-test/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/TestsøknadBuilder.kt
+++ b/enslig-forsorger-test/src/main/kotlin/no/nav/familie/kontrakter/ef/søknad/TestsøknadBuilder.kt
@@ -30,7 +30,7 @@ class TestsøknadBuilder private constructor(
     val situasjon: Situasjon,
     val stønadsstart: Stønadsstart,
 
-    ) {
+) {
 
     /**
      * En builder med defaultverdier for 'Testsøknad', men som kan "overlagres" om man ønsker andre verdier
@@ -215,7 +215,7 @@ class TestsøknadBuilder private constructor(
             lagtTilManuelt: Boolean = true,
             skalBoHosSøker: String? = "jaMenSamarbeiderIkke",
 
-            ): Barn {
+        ): Barn {
             return Barn(
                 Søknadsfelt("Navn", navn),
                 Søknadsfelt(
@@ -339,7 +339,7 @@ class TestsøknadBuilder private constructor(
         fun setStønadstart(
             month: Month = Month.AUGUST,
             fraÅr: Int = 2018,
-            søkerFraBestemtMåned: Boolean = true
+            søkerFraBestemtMåned: Boolean = true,
         ): Builder {
             this.stønadsstart = Stønadsstart(
                 Søknadsfelt("Søker du stønad fra et bestemt tidspunkt", søkerFraBestemtMåned),
@@ -469,7 +469,7 @@ class TestsøknadBuilder private constructor(
             datoperiode = Søknadsfelt("Periode", Datoperiode(fra = fraDato, til = tilDato)),
             belop = Søknadsfelt(label = "Beløp", verdi = beløp),
 
-            )
+        )
 
         fun defaultBarnepass(
             årsakSvarId: String? = "trengerMerPassEnnJevnaldrede",
@@ -563,7 +563,7 @@ class TestsøknadBuilder private constructor(
                     land = Søknadsfelt(
                         label = "Hvor oppholder du og barnet/barna dere?",
                         verdi = "Sverige",
-                        svarId = "SWE"
+                        svarId = "SWE",
                     ),
                     årsakUtenlandsopphold = Søknadsfelt("Hvorfor bodde du i utlandet?", "Granca, Granca, Granca"),
                 ),
@@ -710,10 +710,10 @@ class TestsøknadBuilder private constructor(
                 hvaErMåletMedUtdanningen = Søknadsfelt(
                     "Hva er målet med utdanningen?",
                     "Odio quam nulla at amet eget. Faucibus feugiat orci, nisi a venenatis metus. Tincidunt massa amet sapien velit egestas varius in.\n" +
-                            "\n" +
-                            "Leo sed bibendum sapien eros, dui nunc, purus. Morbi vulputate non facilisi neque pulvinar. Vulputate malesuada risus ipsum scelerisque. Id ac consequat, curabitur fermentum mauris blandit dictum rhoncus nibh. Etiam hendrerit amet tempor ultrices eu ultrices. Enim in parturient at ut tincidunt sit.\n" +
-                            "\n" +
-                            "Leo donec diam vestibulum tempus at dictum lacinia rutrum. Molestie sit netus sagittis sit sodales ultrices orci. Placerat vehicula sit quis in. Nulla nunc, egestas id etiam sit facilisis enim vitae sed.",
+                        "\n" +
+                        "Leo sed bibendum sapien eros, dui nunc, purus. Morbi vulputate non facilisi neque pulvinar. Vulputate malesuada risus ipsum scelerisque. Id ac consequat, curabitur fermentum mauris blandit dictum rhoncus nibh. Etiam hendrerit amet tempor ultrices eu ultrices. Enim in parturient at ut tincidunt sit.\n" +
+                        "\n" +
+                        "Leo donec diam vestibulum tempus at dictum lacinia rutrum. Molestie sit netus sagittis sit sodales ultrices orci. Placerat vehicula sit quis in. Nulla nunc, egestas id etiam sit facilisis enim vitae sed.",
                 ),
                 utdanningEtterGrunnskolen = Søknadsfelt("Har du tatt utdanning etter grunnskolen?", true),
                 tidligereUtdanninger = Søknadsfelt(

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Brevkoder.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/Brevkoder.kt
@@ -21,6 +21,6 @@ object Brevkoder {
         ETTERSENDELSE_TIL_KLAGE_ANKE,
         ETTERSENDELSE_TIL_KLAGE,
         ANKE,
-        ETTERSENDELSE_TIL_ANKE
+        ETTERSENDELSE_TIL_ANKE,
     )
 }

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/saksbehandler/Saksbehandler.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/saksbehandler/Saksbehandler.kt
@@ -8,4 +8,5 @@ class Saksbehandler(
     val fornavn: String,
     val etternavn: String,
     val enhet: String,
+    val enhetsnavn: String?,
 )

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/DokumentInfoTest.kt
@@ -424,9 +424,9 @@ class DokumentInfoTest {
                     dokumentInfoId = "1",
                     brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                     dokumentvarianter =
-                        listOf(
-                            Dokumentvariant(Dokumentvariantformat.ORIGINAL, "Testfil", false),
-                        ),
+                    listOf(
+                        Dokumentvariant(Dokumentvariantformat.ORIGINAL, "Testfil", false),
+                    ),
                 )
 
             // Act
@@ -444,9 +444,9 @@ class DokumentInfoTest {
                     dokumentInfoId = "1",
                     brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                     dokumentvarianter =
-                        listOf(
-                            Dokumentvariant(Dokumentvariantformat.ARKIV, "Testfil", false),
-                        ),
+                    listOf(
+                        Dokumentvariant(Dokumentvariantformat.ARKIV, "Testfil", false),
+                    ),
                 )
 
             // Act

--- a/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
+++ b/felles/src/test/kotlin/no/nav/familie/kontrakter/felles/journalpost/JournalpostTest.kt
@@ -35,12 +35,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     relevanteDatoer =
-                        listOf(
-                            RelevantDato(
-                                dato = LocalDateTime.of(2024, 8, 1, 12, 0),
-                                datotype = "FEIL_DATOTYPE",
-                            ),
+                    listOf(
+                        RelevantDato(
+                            dato = LocalDateTime.of(2024, 8, 1, 12, 0),
+                            datotype = "FEIL_DATOTYPE",
                         ),
+                    ),
                 )
 
             // Act
@@ -58,12 +58,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     relevanteDatoer =
-                        listOf(
-                            RelevantDato(
-                                dato = enDato,
-                                datotype = "DATO_REGISTRERT",
-                            ),
+                    listOf(
+                        RelevantDato(
+                            dato = enDato,
+                            datotype = "DATO_REGISTRERT",
                         ),
+                    ),
                 )
 
             // Act
@@ -145,12 +145,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -166,12 +166,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -220,12 +220,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -241,12 +241,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -295,12 +295,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -316,12 +316,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -340,12 +340,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -361,12 +361,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -382,12 +382,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -403,16 +403,16 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
-                            ),
-                            DokumentInfo(
-                                dokumentInfoId = "2",
-                                brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
                         ),
+                        DokumentInfo(
+                            dokumentInfoId = "2",
+                            brevkode = Brevkoder.BARNETRYGD_UTVIDET_SØKNAD,
+                        ),
+                    ),
                 )
 
             // Act
@@ -479,12 +479,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -501,12 +501,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -573,12 +573,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -595,12 +595,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -623,12 +623,12 @@ class JournalpostTest {
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -648,12 +648,12 @@ class JournalpostTest {
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -711,12 +711,12 @@ class JournalpostTest {
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -736,12 +736,12 @@ class JournalpostTest {
                     journalstatus = Journalstatus.MOTTATT,
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KONTANTSTØTTE_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -839,12 +839,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KLAGE,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KLAGE,
                         ),
+                    ),
                 )
 
             // Act
@@ -860,12 +860,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -909,12 +909,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KLAGE,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KLAGE,
                         ),
+                    ),
                 )
 
             // Act
@@ -931,12 +931,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "IKKE_NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.KLAGE,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.KLAGE,
                         ),
+                    ),
                 )
 
             // Act
@@ -953,12 +953,12 @@ class JournalpostTest {
                 lagJournalpost(
                     kanal = "NAV_NO",
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = Brevkoder.BARNETRYGD_ORDINÆR_SØKNAD,
                         ),
+                    ),
                 )
 
             // Act
@@ -1009,12 +1009,12 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = null,
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = null,
                         ),
+                    ),
                 )
 
             // Act
@@ -1030,23 +1030,23 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = null,
-                                tittel = "AAA",
-                            ),
-                            DokumentInfo(
-                                dokumentInfoId = "2",
-                                brevkode = "2",
-                                tittel = null,
-                            ),
-                            DokumentInfo(
-                                dokumentInfoId = "3",
-                                brevkode = "1",
-                                tittel = "CCC",
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = null,
+                            tittel = "AAA",
                         ),
+                        DokumentInfo(
+                            dokumentInfoId = "2",
+                            brevkode = "2",
+                            tittel = null,
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "3",
+                            brevkode = "1",
+                            tittel = "CCC",
+                        ),
+                    ),
                 )
 
             // Act
@@ -1062,23 +1062,23 @@ class JournalpostTest {
             val journalpost =
                 lagJournalpost(
                     dokumenter =
-                        listOf(
-                            DokumentInfo(
-                                dokumentInfoId = "1",
-                                brevkode = null,
-                                tittel = "AAA",
-                            ),
-                            DokumentInfo(
-                                dokumentInfoId = "2",
-                                brevkode = "2",
-                                tittel = "BBB",
-                            ),
-                            DokumentInfo(
-                                dokumentInfoId = "3",
-                                brevkode = "1",
-                                tittel = "CCC",
-                            ),
+                    listOf(
+                        DokumentInfo(
+                            dokumentInfoId = "1",
+                            brevkode = null,
+                            tittel = "AAA",
                         ),
+                        DokumentInfo(
+                            dokumentInfoId = "2",
+                            brevkode = "2",
+                            tittel = "BBB",
+                        ),
+                        DokumentInfo(
+                            dokumentInfoId = "3",
+                            brevkode = "1",
+                            tittel = "CCC",
+                        ),
+                    ),
                 )
 
             // Act


### PR DESCRIPTION
…der saksbehandler sin signatur i brev

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24673)

Vi ønsker å følge Nav sin brevstandard når det gjelder signaturen i brevene siden vi har fått tilbakemelding på dette. Da er vi nødt til å hente ut saksbehandler sin geografiske Nav-enhet i klartekst for bruk i brev