### PR TITLE
Endret fra IKKE_RELEVANT til IKKE_RELEVANT_IKKE_FØRSTEGANGSSØKNAD

### DIFF
--- a/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/SvarId.kt
+++ b/enslig-forsorger/src/main/kotlin/no/nav/familie/kontrakter/ef/felles/SvarId.kt
@@ -47,6 +47,6 @@ enum class SvarId {
     NOEN_MÅNEDER_OVERSTIGER_6G,
     BRUKER_MOTTAR_IKKE_OVERGANGSSTØNAD,
 
-    //Sagt opp arbeidsforhold
-    IKKE_RELEVANT,
+    // Sagt opp arbeidsforhold
+    IKKE_RELEVANT_IKKE_FØRSTEGANGSSØKNAD,
 }


### PR DESCRIPTION
Tilbakemelding om ny tekst som kan være mer oversiktlig for saksbehandlere. Hadde ingen negativ effekt å legge til ikke_relevant nylig så burde ikke være noen breaking changes
[ref](https://github.com/navikt/familie-kontrakter/pull/1013)