### PR TITLE
Hjelpemetode for å hente ut boolske verdier for søknadsfelt-verdi

### DIFF
--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/BarnetrygdSøknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/BarnetrygdSøknad.kt
@@ -40,3 +40,6 @@ fun <T> Søknadsfelt<T>.bokmålsverdi(): T? {
 fun <T> FellesSøknadsfelt<T>.bokmålsverdi(): T? {
     return this.verdi["nb"]
 }
+
+fun Any?.tilBoolskSvar(): Boolean = this is String && this.equals("JA", ignoreCase = true)
+

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/HentVerdiForSøknadsfeltFraSøknadTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/HentVerdiForSøknadsfeltFraSøknadTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertNotNull
 
 class HentVerdiForSøknadsfeltFraSøknadTest {
 
+    @Test
     fun `skal hente ut verdi for spørsmål`() {
         // Arrange
         val versjonertBarnetrygdSøknad = lesSøknad("søknadMedUtenlandsOpphold.json")
@@ -40,6 +41,28 @@ class HentVerdiForSøknadsfeltFraSøknadTest {
             utenlandsOppholdÅrsak,
             "Barnet har flyttet til Norge permanent de siste tolv månedene",
         )
+    }
+
+    @Test
+    fun `tilBoolskSvar skal returnere true når verdi for spørsmål er JA eller ja`() {
+        //Arrange
+        val versjonertBarnetrygdSøknad = lesSøknad("søknadMedUtenlandsOpphold.json")
+        val søknadsFeltId = SøknadsFeltId.BOR_PÅ_REGISTRERT_ADRESSE
+
+        //Act
+        val verdiForSpørsmål = versjonertBarnetrygdSøknad.søker.spørsmål.hentVerdiForSøknadsfelt(søknadsFeltId).tilBoolskSvar()
+
+        //Assert
+        assertEquals(verdiForSpørsmål, true)
+    }
+
+    @Test
+    fun `tilBoolskSvar skal returnere false for NEI, andre verdier og null`() {
+        // Act & Assert
+        assertEquals(false, "NEI".tilBoolskSvar())
+        assertEquals(false, "nei".tilBoolskSvar())
+        assertEquals(false, 1234.tilBoolskSvar())
+        assertEquals(false, null.tilBoolskSvar())
     }
 
     private fun lesSøknad(søknadFilnavn: String): BarnetrygdSøknad {


### PR DESCRIPTION
Relatert til [Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25323)

Vi ønsker å bruke en hjelpemetode for å oversette "JA" til boolean for å unngå mange steder med  == "JA", når vi sjekker verdien til et spørsmål i søknaden i ba-sak.