### PR TITLE
Hent ut riktig spørsmål for søker

### DIFF
--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/SøknadsFeltId.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/SøknadsFeltId.kt
@@ -4,7 +4,8 @@ package no.nav.familie.kontrakter.ba.søknad.v9
 enum class SøknadsFeltId(val verdiIKontrakt: String) {
     BOR_PÅ_REGISTRERT_ADRESSE("borPåRegistrertAdresse"),
     VÆRT_I_NORGE_I_TOLV_MÅNEDER("værtINorgeITolvMåneder"),
-    PLANLEGGER_Å_BO_I_NORGE_12_MND("planleggerÅBoINorge12Mnd"),
+    PLANLEGGER_Å_BO_I_NORGE_12_MND_BARN("planleggerÅBoINorge12Mnd"),
+    PLANLEGGER_Å_BO_I_NORGE_12_MND_SØKER("planleggerÅBoINorgeTolvMnd"),
     UTENLANDSOPPHOLD_ÅRSAK("utenlandsoppholdÅrsak"),
     OPPHOLDSLAND("oppholdsland"),
     OPPHOLDSLAND_FRA_DATO("oppholdslandFraDato"),

--- a/barnetrygd/src/test/resources/no/nav/familie/kontrakter/ba/søknad/v9/søknadMedUtenlandsOpphold.json
+++ b/barnetrygd/src/test/resources/no/nav/familie/kontrakter/ba/søknad/v9/søknadMedUtenlandsOpphold.json
@@ -201,6 +201,18 @@
           "nn" : "NEI",
           "en" : "NEI"
         }
+      },
+      "planleggerÅBoINorgeTolvMnd" : {
+        "label" : {
+          "en" : "Is it planned that you will live in Norway continuously for more than 12 months?",
+          "nb" : "Er det planlagt at du skal bo sammenhengende i Norge i mer enn tolv måneder?",
+          "nn" : "Er det planlagd at du skal bu i Noreg samanhengande i meir enn tolv månadar?"
+        },
+        "verdi" : {
+          "nb" : "JA",
+          "nn" : "JA",
+          "en" : "JA"
+        }
       }
     },
     "tidligereSamboere" : [],


### PR DESCRIPTION
Legger til en ekstra enum for spørsmål "Planlegger å bo i Norge i 12 mnd" for søker, da feltet er forskjellig for barn og søker