### PR TITLE
Fjernet duplikat av BehandleUnderKjentVedtak oppgavetype som har skrivefeil. 

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgaveRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/oppgave/OpprettOppgaveRequest.kt
@@ -29,7 +29,6 @@ enum class Oppgavetype(val value: String) {
     Fordeling("FDR"),
     BehandleReturpost("RETUR"),
     BehandleSED("BEH_SED"),
-    BehandleUderkjentVedtak("BEH_UND_VED"),
     FordelingSED("FDR_SED"),
     Fremlegg("FREM"),
     Generell("GEN"),


### PR DESCRIPTION
Fant duplikat av oppgavetype BehandUnderKjentVedtak hvor det også er BehandleUderKjentVedtak. Ser ut som skrivefeil og finner ingen bruk av den. Rydding.