### PR TITLE
Ny data class `FagsakTilgang` 

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilgangskontroll/FagsakTilgang.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/tilgangskontroll/FagsakTilgang.kt
@@ -1,0 +1,6 @@
+package no.nav.familie.kontrakter.felles.tilgangskontroll
+
+data class FagsakTilgang(
+    val harTilgang: Boolean,
+    val begrunnelse: String? = null,
+)


### PR DESCRIPTION
For å finne ut om en saksbehandler skal ha tilgang til en klagebehandling for BA/KS må vi sjekke om saksbehandler har tilgang til den eksterne fagsaken i henholdsvis BA- og KS -sak. Legger derfor til en ny data class som skal brukes i respons ved tilgangssjekk.