### PR TITLE
Utvidelse av organisjasjonskontrakt for å få med adresse.

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/organisasjon/Organisasjon.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/organisasjon/Organisasjon.kt
@@ -3,4 +3,11 @@ package no.nav.familie.kontrakter.felles.organisasjon
 data class Organisasjon(
     val organisasjonsnummer: String,
     val navn: String,
+    val adresse: OrganisasjonAdresse? = null,
+)
+
+// https://github.com/navikt/ereg-services/blob/main/src/main/java/no/nav/ereg/provider/rs/organisasjon/contract/Adresse.java
+data class OrganisasjonAdresse(
+    val type: String,
+    val kommunenummer: String?,
 )


### PR DESCRIPTION
 I første versjon kun kommunenummer og hva slags type adresse dette er. For å kunne identifisere institusjoner som skal ha finnmarkstillegg