### PR TITLE
Legg til OppholdAnnetSted

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/personopplysning/Personinfo.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/personopplysning/Personinfo.kt
@@ -131,3 +131,25 @@ enum class KJOENN {
     KVINNE,
     UKJENT,
 }
+
+enum class OppholdAnnetSted(
+    val kode: String,
+) {
+    MILITAER("militaer"),
+    PENDLER("pendler"),
+    UTENRIKS("utenriks"),
+    PAA_SVALBARD("paaSvalbard"),
+    ;
+
+    override fun toString(): String =
+        when (this) {
+            MILITAER -> "militær"
+            PENDLER -> "pendler"
+            UTENRIKS -> "utenriks"
+            PAA_SVALBARD -> "Svalbard"
+        }
+
+    companion object {
+        fun parse(verdi: String?): OppholdAnnetSted? = entries.firstOrNull { it.kode == verdi || it.name == verdi }
+    }
+}


### PR DESCRIPTION
- Legger til enumklasse for `OppholdAnnetSted`. Verdien på feltet varierer mellom enumnavn og tilhørende `kode`, så enumet kan ikke brukes direkte i `Oppholdsadresse`.