### PR TITLE
Utvider generalisering av BarnetrygdSøknad og fjerner dokumentasjonsbehov for Svalbard i V10 av barnetrygdsøknad

### DIFF
--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/VersjonertBarnetrygdSøknad.kt
@@ -9,13 +9,13 @@ import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import no.nav.familie.kontrakter.felles.søknad.BaksSøknadBase
+import no.nav.familie.kontrakter.felles.søknad.BaSøknadBase
 import no.nav.familie.kontrakter.felles.søknad.MissingVersionException
 import no.nav.familie.kontrakter.felles.søknad.UnsupportedVersionException
+import no.nav.familie.kontrakter.ba.søknad.v10.BarnetrygdSøknad as BarnetrygdSøknadV10
 import no.nav.familie.kontrakter.ba.søknad.v7.Søknad as BarnetrygdSøknadV7
 import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as BarnetrygdSøknadV8
 import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad as BarnetrygdSøknadV9
-import no.nav.familie.kontrakter.ba.søknad.v10.BarnetrygdSøknad as BarnetrygdSøknadV10
 
 class VersjonertBarnetrygdSøknadSerializer : JsonSerializer<VersjonertBarnetrygdSøknad>() {
     override fun serialize(
@@ -54,12 +54,12 @@ class VersjonertBarnetrygdSøknadDeserializer : JsonDeserializer<VersjonertBarne
 @JsonSerialize(using = VersjonertBarnetrygdSøknadSerializer::class)
 @JsonDeserialize(using = VersjonertBarnetrygdSøknadDeserializer::class)
 sealed class VersjonertBarnetrygdSøknad(
-    open val barnetrygdSøknad: BaksSøknadBase,
+    open val barnetrygdSøknad: BaSøknadBase,
 )
 
 // Egen sealed class for versjoner av barnetrygdsøknad vi støtter ved mottak. Dette vil være de 2 siste versjonene til enhver tid.
 sealed class StøttetVersjonertBarnetrygdSøknad(
-    override val barnetrygdSøknad: BaksSøknadBase,
+    override val barnetrygdSøknad: BaSøknadBase,
 ) : VersjonertBarnetrygdSøknad(barnetrygdSøknad = barnetrygdSøknad)
 
 data class VersjonertBarnetrygdSøknadV7(

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknad.kt
@@ -2,7 +2,6 @@ package no.nav.familie.kontrakter.ba.søknad.v10
 
 import no.nav.familie.kontrakter.ba.søknad.v1.SIVILSTANDTYPE
 import no.nav.familie.kontrakter.ba.søknad.v1.SøknadAdresse
-
 import no.nav.familie.kontrakter.ba.søknad.v4.Locale
 import no.nav.familie.kontrakter.ba.søknad.v4.NåværendeSamboer
 import no.nav.familie.kontrakter.ba.søknad.v4.SpørsmålId
@@ -12,6 +11,7 @@ import no.nav.familie.kontrakter.ba.søknad.v4.TidligereSamboer
 import no.nav.familie.kontrakter.ba.søknad.v4.Utenlandsopphold
 import no.nav.familie.kontrakter.ba.søknad.v5.RegistrertBostedType
 import no.nav.familie.kontrakter.ba.søknad.v7.IdNummer
+import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelder
 import no.nav.familie.kontrakter.ba.søknad.v8.Arbeidsperiode
 import no.nav.familie.kontrakter.ba.søknad.v8.Barn
@@ -19,7 +19,7 @@ import no.nav.familie.kontrakter.ba.søknad.v8.EøsBarnetrygdsperiode
 import no.nav.familie.kontrakter.ba.søknad.v8.Omsorgsperson
 import no.nav.familie.kontrakter.ba.søknad.v8.Pensjonsperiode
 import no.nav.familie.kontrakter.ba.søknad.v8.Utbetalingsperiode
-import no.nav.familie.kontrakter.felles.søknad.BaksSøknadBase
+import no.nav.familie.kontrakter.felles.søknad.BaSøknadBase
 import no.nav.familie.kontrakter.felles.søknad.BaksSøknadPersonBase
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt as FellesSøknadsfelt
 
@@ -27,14 +27,14 @@ data class BarnetrygdSøknad(
     override val kontraktVersjon: Int,
     override val søker: Søker,
     override val barn: List<Barn>,
+    override val dokumentasjon: List<Søknaddokumentasjon>,
+    override val søknadstype: Søknadstype,
     val antallEøsSteg: Int,
-    val søknadstype: Søknadstype,
     val finnesPersonMedAdressebeskyttelse: Boolean,
     val spørsmål: Map<SpørsmålId, Søknadsfelt<Any>>,
-    val dokumentasjon: List<Søknaddokumentasjon>,
     val teksterUtenomSpørsmål: Map<SpørsmålId, Map<Locale, String>>,
     val originalSpråk: Locale,
-) : BaksSøknadBase
+) : BaSøknadBase
 
 data class Søker(
     override val ident: FellesSøknadsfelt<String>,
@@ -76,27 +76,3 @@ data class SvalbardPeriode(
     val fraDatoSvalbardOpphold: Søknadsfelt<String?>,
     val tilDatoSvalbardOpphold: Søknadsfelt<String?>,
 )
-data class Søknaddokumentasjon(
-    val dokumentasjonsbehov: Dokumentasjonsbehov,
-    val harSendtInn: Boolean,
-    val opplastedeVedlegg: List<Søknadsvedlegg>,
-    val dokumentasjonSpråkTittel: Map<Locale, String>,
-)
-
-data class Søknadsvedlegg(
-    val dokumentId: String,
-    val navn: String,
-    val tittel: Dokumentasjonsbehov,
-)
-
-enum class Dokumentasjonsbehov {
-    AVTALE_DELT_BOSTED,
-    VEDTAK_OPPHOLDSTILLATELSE,
-    ADOPSJON_DATO,
-    BEKREFTELSE_FRA_BARNEVERN,
-    BOR_FAST_MED_SØKER,
-    SEPARERT_SKILT_ENKE,
-    MEKLINGSATTEST,
-    ANNEN_DOKUMENTASJON,
-    OPPHOLD_SVALBARD,
-}

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknad.kt
@@ -12,8 +12,6 @@ import no.nav.familie.kontrakter.ba.søknad.v4.TidligereSamboer
 import no.nav.familie.kontrakter.ba.søknad.v4.Utenlandsopphold
 import no.nav.familie.kontrakter.ba.søknad.v5.RegistrertBostedType
 import no.nav.familie.kontrakter.ba.søknad.v7.IdNummer
-import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
-import no.nav.familie.kontrakter.ba.søknad.v7.Søknadsvedlegg
 import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelder
 import no.nav.familie.kontrakter.ba.søknad.v8.Arbeidsperiode
 import no.nav.familie.kontrakter.ba.søknad.v8.Barn
@@ -83,6 +81,12 @@ data class Søknaddokumentasjon(
     val harSendtInn: Boolean,
     val opplastedeVedlegg: List<Søknadsvedlegg>,
     val dokumentasjonSpråkTittel: Map<Locale, String>,
+)
+
+data class Søknadsvedlegg(
+    val dokumentId: String,
+    val navn: String,
+    val tittel: Dokumentasjonsbehov,
 )
 
 enum class Dokumentasjonsbehov {

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v4/Søknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v4/Søknad.kt
@@ -2,6 +2,8 @@ package no.nav.familie.kontrakter.ba.søknad.v4
 
 import no.nav.familie.kontrakter.ba.søknad.v1.SIVILSTANDTYPE
 import no.nav.familie.kontrakter.ba.søknad.v1.SøknadAdresse
+import no.nav.familie.kontrakter.felles.søknad.BaFellesSøknadstype
+import no.nav.familie.kontrakter.felles.søknad.BaSøknadstype
 import java.time.LocalDate
 
 typealias Locale = String
@@ -15,10 +17,18 @@ data class Søknadsfelt<T>(
 enum class Søknadstype(
     val tittel: String,
     val søknadskode: String,
-) {
+) : BaSøknadstype {
     IKKE_SATT("SØKNADSTYPE MANGLER", "SØKNADSTYPE MANGLER"),
     ORDINÆR("Søknad om barnetrygd ordinær", "NAV 33-00.07"),
     UTVIDET("Søknad om utvidet barnetrygd", "NAV 33-00.09"),
+    ;
+
+    override fun tilFellesSøknadstype(): BaFellesSøknadstype =
+        when (this) {
+            IKKE_SATT -> BaFellesSøknadstype.IkkeSatt
+            ORDINÆR -> BaFellesSøknadstype.Ordinær
+            UTVIDET -> BaFellesSøknadstype.Utvidet
+        }
 }
 
 @Deprecated("Bruk v5", replaceWith = ReplaceWith("no.nav.familie.kontrakter.ba.søknad.v5.Søknad"))

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v7/Søknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v7/Søknad.kt
@@ -10,7 +10,11 @@ import no.nav.familie.kontrakter.ba.søknad.v4.TidligereSamboer
 import no.nav.familie.kontrakter.ba.søknad.v4.Utenlandsopphold
 import no.nav.familie.kontrakter.ba.søknad.v5.RegistrertBostedType
 import no.nav.familie.kontrakter.ba.søknad.v6.AndreForelderUtvidet
-import no.nav.familie.kontrakter.felles.søknad.BaksSøknadBase
+import no.nav.familie.kontrakter.felles.søknad.BaDokumentasjonsbehov
+import no.nav.familie.kontrakter.felles.søknad.BaFellesDokumentasjonsbehov
+import no.nav.familie.kontrakter.felles.søknad.BaSøknadBase
+import no.nav.familie.kontrakter.felles.søknad.BaSøknaddokumentasjon
+import no.nav.familie.kontrakter.felles.søknad.BaSøknadsvedlegg
 import no.nav.familie.kontrakter.felles.søknad.BaksSøknadPersonBase
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
 
@@ -19,22 +23,22 @@ data class Søknad(
     override val kontraktVersjon: Int,
     override val søker: Søker,
     override val barn: List<Barn>,
+    override val dokumentasjon: List<Søknaddokumentasjon>,
+    override val søknadstype: Søknadstype,
     val antallEøsSteg: Int,
-    val søknadstype: Søknadstype,
     val spørsmål: Map<SpørsmålId, Søknadsfelt<Any>>,
-    val dokumentasjon: List<Søknaddokumentasjon>,
     val teksterUtenomSpørsmål: Map<SpørsmålId, Map<Locale, String>>,
     val originalSpråk: Locale,
-) : BaksSøknadBase
+) : BaSøknadBase
 
 data class Søknaddokumentasjon(
-    val dokumentasjonsbehov: Dokumentasjonsbehov,
-    val harSendtInn: Boolean,
-    val opplastedeVedlegg: List<Søknadsvedlegg>,
+    override val dokumentasjonsbehov: Dokumentasjonsbehov,
+    override val harSendtInn: Boolean,
+    override val opplastedeVedlegg: List<Søknadsvedlegg>,
     val dokumentasjonSpråkTittel: Map<Locale, String>,
-)
+) : BaSøknaddokumentasjon
 
-enum class Dokumentasjonsbehov {
+enum class Dokumentasjonsbehov : BaDokumentasjonsbehov {
     AVTALE_DELT_BOSTED,
     VEDTAK_OPPHOLDSTILLATELSE,
     ADOPSJON_DATO,
@@ -43,13 +47,26 @@ enum class Dokumentasjonsbehov {
     SEPARERT_SKILT_ENKE,
     MEKLINGSATTEST,
     ANNEN_DOKUMENTASJON,
+    ;
+
+    override fun tilFellesDokumentasjonsbehov(): BaFellesDokumentasjonsbehov =
+        when (this) {
+            AVTALE_DELT_BOSTED -> BaFellesDokumentasjonsbehov.AvtaleDeltBosted
+            VEDTAK_OPPHOLDSTILLATELSE -> BaFellesDokumentasjonsbehov.VedtakOppholdstillatelse
+            ADOPSJON_DATO -> BaFellesDokumentasjonsbehov.AdopsjonDato
+            BEKREFTELSE_FRA_BARNEVERN -> BaFellesDokumentasjonsbehov.BekreftelseFraBarnevern
+            BOR_FAST_MED_SØKER -> BaFellesDokumentasjonsbehov.BorFastMedSøker
+            SEPARERT_SKILT_ENKE -> BaFellesDokumentasjonsbehov.SeparertSkiltEnke
+            MEKLINGSATTEST -> BaFellesDokumentasjonsbehov.Meklingsattest
+            ANNEN_DOKUMENTASJON -> BaFellesDokumentasjonsbehov.AnnenDokumentasjon
+        }
 }
 
 data class Søknadsvedlegg(
-    val dokumentId: String,
-    val navn: String,
-    val tittel: Dokumentasjonsbehov,
-)
+    override val dokumentId: String,
+    override val navn: String,
+    override val tittel: Dokumentasjonsbehov,
+) : BaSøknadsvedlegg
 
 @Deprecated("Bruk v8", replaceWith = ReplaceWith("no.nav.familie.kontrakter.ba.søknad.v8.Søker"))
 data class Søker(

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v8/Søknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v8/Søknad.kt
@@ -11,7 +11,7 @@ import no.nav.familie.kontrakter.ba.søknad.v4.Utenlandsopphold
 import no.nav.familie.kontrakter.ba.søknad.v5.RegistrertBostedType
 import no.nav.familie.kontrakter.ba.søknad.v7.IdNummer
 import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
-import no.nav.familie.kontrakter.felles.søknad.BaksSøknadBase
+import no.nav.familie.kontrakter.felles.søknad.BaSøknadBase
 import no.nav.familie.kontrakter.felles.søknad.BaksSøknadPersonBase
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
 
@@ -19,13 +19,13 @@ data class Søknad(
     override val kontraktVersjon: Int,
     override val søker: Søker,
     override val barn: List<Barn>,
+    override val dokumentasjon: List<Søknaddokumentasjon>,
+    override val søknadstype: Søknadstype,
     val antallEøsSteg: Int,
-    val søknadstype: Søknadstype,
     val spørsmål: Map<SpørsmålId, Søknadsfelt<Any>>,
-    val dokumentasjon: List<Søknaddokumentasjon>,
     val teksterUtenomSpørsmål: Map<SpørsmålId, Map<Locale, String>>,
     val originalSpråk: Locale,
-) : BaksSøknadBase
+) : BaSøknadBase
 
 data class Søker(
     override val ident: Søknadsfelt<String>,

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/BarnetrygdSøknad.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v9/BarnetrygdSøknad.kt
@@ -7,21 +7,21 @@ import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
 import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v8.Barn
 import no.nav.familie.kontrakter.ba.søknad.v8.Søker
-import no.nav.familie.kontrakter.felles.søknad.BaksSøknadBase
+import no.nav.familie.kontrakter.felles.søknad.BaSøknadBase
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt as FellesSøknadsfelt
 
 data class BarnetrygdSøknad(
     override val kontraktVersjon: Int,
     override val søker: Søker,
     override val barn: List<Barn>,
+    override val dokumentasjon: List<Søknaddokumentasjon>,
+    override val søknadstype: Søknadstype,
     val antallEøsSteg: Int,
-    val søknadstype: Søknadstype,
     val finnesPersonMedAdressebeskyttelse: Boolean,
     val spørsmål: Map<SpørsmålId, Søknadsfelt<Any>>,
-    val dokumentasjon: List<Søknaddokumentasjon>,
     val teksterUtenomSpørsmål: Map<SpørsmålId, Map<Locale, String>>,
     val originalSpråk: Locale,
-) : BaksSøknadBase
+) : BaSøknadBase
 
 @JvmName("hentVerdiForV4Søknadsfelt")
 fun Map<String, Søknadsfelt<Any>>.hentVerdiForSøknadsfelt(søknadsFeltId: SøknadsFeltId): Any? =

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/BarnetrygdSøknadDataGenerator.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/BarnetrygdSøknadDataGenerator.kt
@@ -5,16 +5,15 @@ import no.nav.familie.kontrakter.ba.søknad.v1.SøknadAdresse
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
 import no.nav.familie.kontrakter.ba.søknad.v5.RegistrertBostedType
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
+import no.nav.familie.kontrakter.ba.søknad.v10.BarnetrygdSøknad as BarnetrygdSøknadV10
+import no.nav.familie.kontrakter.ba.søknad.v10.Søker as SøkerV10
 import no.nav.familie.kontrakter.ba.søknad.v7.Barn as BarnV7
 import no.nav.familie.kontrakter.ba.søknad.v7.Søker as SøkerV7
 import no.nav.familie.kontrakter.ba.søknad.v7.Søknad as BarnetrygdSøknadV7
 import no.nav.familie.kontrakter.ba.søknad.v8.Barn as BarnV8
 import no.nav.familie.kontrakter.ba.søknad.v8.Søker as SøkerV8
-import no.nav.familie.kontrakter.ba.søknad.v10.Søker as SøkerV10
 import no.nav.familie.kontrakter.ba.søknad.v8.Søknad as BarnetrygdSøknadV8
 import no.nav.familie.kontrakter.ba.søknad.v9.BarnetrygdSøknad as BarnetrygdSøknadV9
-import no.nav.familie.kontrakter.ba.søknad.v10.BarnetrygdSøknad as BarnetrygdSøknadV10
-
 
 fun lagBarnetrygdSøknadV10(
     søkerFnr: String,

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/søknad/Søknad.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/søknad/Søknad.kt
@@ -8,11 +8,72 @@ interface BaksSøknadBase {
     fun personerISøknad(): List<String> = listOf(søker.fnr).plus(barn.map { it.fnr })
 }
 
+interface BaSøknadBase : BaksSøknadBase {
+    val dokumentasjon: List<BaSøknaddokumentasjon>
+    val søknadstype: BaSøknadstype
+}
+
+interface BaSøknadstype {
+    fun tilFellesSøknadstype(): BaFellesSøknadstype
+}
+
+sealed interface BaFellesSøknadstype {
+    object Ordinær : BaFellesSøknadstype
+
+    object Utvidet : BaFellesSøknadstype
+
+    object IkkeSatt : BaFellesSøknadstype
+
+    data class UkjentSøknadstype(
+        val ukjentSøknadstype: String,
+    ) : BaFellesSøknadstype
+}
+
 interface BaksSøknadPersonBase {
     val ident: Søknadsfelt<String>
 
     val fnr: String
         get() = ident.verdi.values.first()
+}
+
+interface BaSøknaddokumentasjon {
+    val dokumentasjonsbehov: BaDokumentasjonsbehov
+    val harSendtInn: Boolean
+    val opplastedeVedlegg: List<BaSøknadsvedlegg>
+}
+
+interface BaSøknadsvedlegg {
+    val dokumentId: String
+    val navn: String
+    val tittel: BaDokumentasjonsbehov
+}
+
+interface BaDokumentasjonsbehov {
+    fun tilFellesDokumentasjonsbehov(): BaFellesDokumentasjonsbehov
+}
+
+sealed interface BaFellesDokumentasjonsbehov {
+    object AdopsjonDato : BaFellesDokumentasjonsbehov
+
+    object AvtaleDeltBosted : BaFellesDokumentasjonsbehov
+
+    object VedtakOppholdstillatelse : BaFellesDokumentasjonsbehov
+
+    object BekreftelseFraBarnevern : BaFellesDokumentasjonsbehov
+
+    object BorFastMedSøker : BaFellesDokumentasjonsbehov
+
+    object SeparertSkiltEnke : BaFellesDokumentasjonsbehov
+
+    object Meklingsattest : BaFellesDokumentasjonsbehov
+
+    object AnnenDokumentasjon : BaFellesDokumentasjonsbehov
+
+    object OppholdSvalbard : BaFellesDokumentasjonsbehov
+
+    data class UkjentDokumentasjonsbehov(
+        val ukjentDokumentasjonsbehov: String,
+    ) : BaFellesDokumentasjonsbehov
 }
 
 typealias Locale = String

--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/søknad/Søknad.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/søknad/Søknad.kt
@@ -69,8 +69,6 @@ sealed interface BaFellesDokumentasjonsbehov {
 
     object AnnenDokumentasjon : BaFellesDokumentasjonsbehov
 
-    object OppholdSvalbard : BaFellesDokumentasjonsbehov
-
     data class UkjentDokumentasjonsbehov(
         val ukjentDokumentasjonsbehov: String,
     ) : BaFellesDokumentasjonsbehov


### PR DESCRIPTION
Det er besluttet at vi ikke skal ha noe dokumentasjonskrav for personer som opplyser at de bor på Svalbard med barna sine så fjerner det fra V10 av BarnetrygdSøknad.

Utvider samtidig generaliseringen av BarnetrygdSøknad med interfacet `BaSøknadBase` hvor vi kan håndtere dokumentasjon og søknadstype felles.