### PR TITLE
Utvider Organisasjon til å ha med hele adresse

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/organisasjon/Organisasjon.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/organisasjon/Organisasjon.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.kontrakter.felles.organisasjon
 
+import java.time.LocalDate
+
 data class Organisasjon(
     val organisasjonsnummer: String,
     val navn: String,
@@ -9,5 +11,15 @@ data class Organisasjon(
 // https://github.com/navikt/ereg-services/blob/main/src/main/java/no/nav/ereg/provider/rs/organisasjon/contract/Adresse.java
 data class OrganisasjonAdresse(
     val type: String,
+    val adresselinje1: String?,
+    val adresselinje2: String?,
+    val adresselinje3: String?,
+    val postnummer: String?,
     val kommunenummer: String?,
+    val gyldighetsperiode: Gyldighetsperiode?,
+)
+
+data class Gyldighetsperiode(
+    val fom: LocalDate?,
+    val tom: LocalDate?,
 )


### PR DESCRIPTION
Tilgjengligjør mer infoen for en organisasjon. Adresse normalt returnerer som:

```
{
        "type": "Forretningsadresse",
        "adresselinje1": "Gatenavn 42",
        "postnummer": "1732",
        "landkode": "NO",
        "kommunenummer": "4242",
        "bruksperiode": {
          "fom": "2024-01-01T07:39:14.918"
        },
        "gyldighetsperiode": {
          "fom": "2023-12-31"
        }
      }
```
