### PR TITLE
Legger til SvalbardKommune-enum med hjelpemetode for å sjekke om en kommune er på Svalbard

### DIFF
--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/svalbardtillegg/SvalbardKommune.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/svalbardtillegg/SvalbardKommune.kt
@@ -1,0 +1,11 @@
+package no.nav.familie.kontrakter.ba.svalbardtillegg
+
+import no.nav.familie.kontrakter.ba.svalbardtillegg.SvalbardKommune.entries
+
+enum class SvalbardKommune(
+    val kommunenummer: String,
+) {
+    SVALBARD("2100"),
+}
+
+fun erKommunePåSvalbard(kommunenummer: String): Boolean = entries.any { it.kommunenummer == kommunenummer }

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/svalbardtillegg/SvalbardKommuneTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/svalbardtillegg/SvalbardKommuneTest.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.kontrakter.ba.svalbardtillegg
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SvalbardKommuneTest {
+    @Nested
+    inner class ErSvalbardKommune {
+        @Test
+        fun `skal returnere true dersom kommunenummer samsvarer med en av kommunene på Svalbard`() {
+            // Act & Assert
+            val erKommunePåSvalbard = erKommunePåSvalbard("2100")
+
+            assertTrue(erKommunePåSvalbard)
+        }
+
+        @Test
+        fun `skal returnere false dersom kommunenummer ikke samsvarer med en av kommunene på Svalbard`() {
+            // Act & Assert
+            val erKommunePåSvalbard = erKommunePåSvalbard("1234")
+
+            assertFalse(erKommunePåSvalbard)
+        }
+    }
+}


### PR DESCRIPTION
Det er foreløpig bare 1 kommune på Svalbard så mulig dette er litt i overkant, men da skal det i hvert fall være greit å legge til flere kommuner i fremtiden dersom man bestemmer seg for at Svalbard skal ha flere kommuner.