### PR TITLE
Branch for å deploye legacy kontrakter med jackson 2 og spring boot 3.

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -2,7 +2,7 @@ name: Build-Deploy
 on:
   push:
     branches:
-      - main
+      - main-jackson2-spring3
 
 jobs:
   build-and-deploy-artifact:


### PR DESCRIPTION
Denne PRen er for dokumentasjon. Den skal *IKKE* merges 

`main`-branchen bruker spring boot 4 med jackson3. Kontrakten blir på versjon 4
 

Hvis man ønsker endringer kontrakter som starter på versjon 3, og som bruker jackson 2, så kan man merge koden ned i `main-jackson2-spring3`. Den vil da bli deployet