### PR TITLE
Adresse til org kan mangle postnummer og kommunenummer. Da tryner mapping

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/organisasjon/Organisasjon.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/organisasjon/Organisasjon.kt
@@ -14,8 +14,8 @@ data class OrganisasjonAdresse(
     val adresselinje1: String?,
     val adresselinje2: String?,
     val adresselinje3: String?,
-    val postnummer: String,
-    val kommunenummer: String,
+    val postnummer: String?,
+    val kommunenummer: String?,
     val gyldighetsperiode: Gyldighetsperiode?,
 )
 


### PR DESCRIPTION
[NAV-28441
](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-28441)
OrganisasjonAdresse kan mangle postnummer og kommunenummer. Typisk forrentningsadresse utenlandsk firma. Da tryner kallet i integrasjoner.