### PR TITLE
Mer grunding inputvalidering av Barnetrygd-søknad

### DIFF
--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
@@ -5,6 +5,8 @@ import no.nav.familie.kontrakter.ba.søknad.UGYLDIGE_TEGN_REGEX
 import no.nav.familie.kontrakter.ba.søknad.Valideringsfeil
 import no.nav.familie.kontrakter.ba.søknad.v4.Locale
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt
+import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelder
+import no.nav.familie.kontrakter.ba.søknad.v8.Omsorgsperson
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt as FellesSøknadsfelt
 
 class BarnetrygdSøknadV10Validator {
@@ -23,6 +25,13 @@ class BarnetrygdSøknadV10Validator {
             // Valider spørsmål på toppnivå
             søknad.spørsmål.forEach { (spørsmålId, søknadsfelt) ->
                 feil.addAll(validerSøknadsfelt(søknadsfelt, "spørsmål.$spørsmålId"))
+            }
+
+            // Valider teksterUtenomSpørsmål
+            søknad.teksterUtenomSpørsmål.forEach { (spørsmålId, localeMap) ->
+                localeMap.forEach { (locale, tekst) ->
+                    feil.addAll(validerString(tekst, "teksterUtenomSpørsmål.$spørsmålId", locale))
+                }
             }
 
             return feil
@@ -125,6 +134,176 @@ class BarnetrygdSøknadV10Validator {
                 feil.addAll(validerFellesSøknadsfelt(periode, "$baseSti.svalbardOppholdPerioder[$index]"))
             }
 
+            // Valider andreForelder
+            barn.andreForelder?.let {
+                feil.addAll(validerAndreForelder(it, "$baseSti.andreForelder"))
+            }
+
+            // Valider omsorgsperson
+            barn.omsorgsperson?.let {
+                feil.addAll(validerOmsorgsperson(it, "$baseSti.omsorgsperson"))
+            }
+
+            return feil
+        }
+
+        private fun validerAndreForelder(
+            andreForelder: AndreForelder,
+            baseSti: String,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            // Enkeltfelt
+            feil.addAll(validerFellesSøknadsfelt(andreForelder.kanIkkeGiOpplysninger, "$baseSti.kanIkkeGiOpplysninger"))
+            andreForelder.navn?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.navn")) }
+            andreForelder.fnr?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.fnr")) }
+            andreForelder.fødselsdato?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.fødselsdato")) }
+            andreForelder.arbeidUtlandet?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.arbeidUtlandet")) }
+            andreForelder.pensjonUtland?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pensjonUtland")) }
+            andreForelder.skriftligAvtaleOmDeltBosted?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.skriftligAvtaleOmDeltBosted")) }
+            andreForelder.pensjonNorge?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pensjonNorge")) }
+            andreForelder.arbeidNorge?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.arbeidNorge")) }
+            andreForelder.andreUtbetalinger?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.andreUtbetalinger")) }
+            andreForelder.adresse?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.adresse")) }
+            andreForelder.pågåendeSøknadFraAnnetEøsLand?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pågåendeSøknadFraAnnetEøsLand")) }
+            andreForelder.pågåendeSøknadHvilketLand?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pågåendeSøknadHvilketLand")) }
+            andreForelder.barnetrygdFraEøs?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.barnetrygdFraEøs")) }
+
+            // Lister
+            andreForelder.idNummer.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.idNummer[$index]"))
+            }
+            andreForelder.arbeidsperioderUtland.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.arbeidsperioderUtland[$index]"))
+            }
+            andreForelder.pensjonsperioderUtland.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.pensjonsperioderUtland[$index]"))
+            }
+            andreForelder.arbeidsperioderNorge.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.arbeidsperioderNorge[$index]"))
+            }
+            andreForelder.pensjonsperioderNorge.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.pensjonsperioderNorge[$index]"))
+            }
+            andreForelder.andreUtbetalingsperioder.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.andreUtbetalingsperioder[$index]"))
+            }
+            andreForelder.eøsBarnetrygdsperioder.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.eøsBarnetrygdsperioder[$index]"))
+            }
+
+            // Utvidet
+            andreForelder.utvidet.søkerHarBoddMedAndreForelder?.let {
+                feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.utvidet.søkerHarBoddMedAndreForelder"))
+            }
+            andreForelder.utvidet.søkerFlyttetFraAndreForelderDato?.let {
+                feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.utvidet.søkerFlyttetFraAndreForelderDato"))
+            }
+
+            return feil
+        }
+
+        private fun validerOmsorgsperson(
+            omsorgsperson: Omsorgsperson,
+            baseSti: String,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            // Enkeltfelt
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.navn, "$baseSti.navn"))
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.slektsforhold, "$baseSti.slektsforhold"))
+            omsorgsperson.slektsforholdSpesifisering?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.slektsforholdSpesifisering")) }
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.idNummer, "$baseSti.idNummer"))
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.adresse, "$baseSti.adresse"))
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.arbeidUtland, "$baseSti.arbeidUtland"))
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.arbeidNorge, "$baseSti.arbeidNorge"))
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.pensjonUtland, "$baseSti.pensjonUtland"))
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.pensjonNorge, "$baseSti.pensjonNorge"))
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.andreUtbetalinger, "$baseSti.andreUtbetalinger"))
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.pågåendeSøknadFraAnnetEøsLand, "$baseSti.pågåendeSøknadFraAnnetEøsLand"))
+            omsorgsperson.pågåendeSøknadHvilketLand?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pågåendeSøknadHvilketLand")) }
+            feil.addAll(validerFellesSøknadsfelt(omsorgsperson.barnetrygdFraEøs, "$baseSti.barnetrygdFraEøs"))
+
+            // Lister
+            omsorgsperson.arbeidsperioderUtland.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.arbeidsperioderUtland[$index]"))
+            }
+            omsorgsperson.arbeidsperioderNorge.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.arbeidsperioderNorge[$index]"))
+            }
+            omsorgsperson.pensjonsperioderUtland.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.pensjonsperioderUtland[$index]"))
+            }
+            omsorgsperson.pensjonsperioderNorge.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.pensjonsperioderNorge[$index]"))
+            }
+            omsorgsperson.andreUtbetalingsperioder.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.andreUtbetalingsperioder[$index]"))
+            }
+            omsorgsperson.eøsBarnetrygdsperioder.forEachIndexed { index, felt ->
+                feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.eøsBarnetrygdsperioder[$index]"))
+            }
+
+            return feil
+        }
+
+        private fun validerString(
+            verdi: String,
+            objectPath: String,
+            locale: Locale,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            if (verdi.length > MAKS_LENGDE) {
+                feil.add(
+                    Valideringsfeil(
+                        objectPath = objectPath,
+                        locale = locale,
+                        feilmelding = "Verdi overskrider maksimal lengde på $MAKS_LENGDE tegn (faktisk: ${verdi.length})",
+                    ),
+                )
+            }
+
+            if (UGYLDIGE_TEGN_REGEX.containsMatchIn(verdi)) {
+                feil.add(
+                    Valideringsfeil(
+                        objectPath = objectPath,
+                        locale = locale,
+                        feilmelding = "Verdi inneholder ugyldige tegn: $verdi",
+                    ),
+                )
+            }
+
+            return feil
+        }
+
+        private fun validerVerdiRekursivt(
+            verdi: Any?,
+            objectPath: String,
+            locale: Locale,
+        ): List<Valideringsfeil> {
+            if (verdi == null) return emptyList()
+
+            val feil = mutableListOf<Valideringsfeil>()
+
+            when (verdi) {
+                is String -> {
+                    feil.addAll(validerString(verdi, objectPath, locale))
+                }
+
+                is Map<*, *> -> {
+                    verdi.forEach { (key, value) ->
+                        feil.addAll(validerVerdiRekursivt(value, "$objectPath.$key", locale))
+                    }
+                }
+
+                is Collection<*> -> {
+                    verdi.forEachIndexed { index, element ->
+                        feil.addAll(validerVerdiRekursivt(element, "$objectPath[$index]", locale))
+                    }
+                }
+            }
+
             return feil
         }
 
@@ -156,27 +335,9 @@ class BarnetrygdSøknadV10Validator {
                 }
             }
 
-            // Valider verdi - sjekk kun String-verdier
+            // Valider verdi - traverser rekursivt for å finne alle String-verdier
             søknadsfelt.verdi.forEach { (locale, verdi) ->
-                if (verdi is String && verdi.length > MAKS_LENGDE) {
-                    feil.add(
-                        Valideringsfeil(
-                            objectPath = "$objectPath.verdi",
-                            locale = locale,
-                            feilmelding = "Verdi overskrider maksimal lengde på $MAKS_LENGDE tegn (faktisk: ${verdi.length})",
-                        ),
-                    )
-                }
-
-                if (verdi is String && UGYLDIGE_TEGN_REGEX.containsMatchIn(verdi)) {
-                    feil.add(
-                        Valideringsfeil(
-                            objectPath = "$objectPath.verdi",
-                            locale = locale,
-                            feilmelding = "Verdi inneholder ugyldige tegn: $verdi",
-                        ),
-                    )
-                }
+                feil.addAll(validerVerdiRekursivt(verdi, "$objectPath.verdi", locale))
             }
 
             return feil
@@ -210,27 +371,9 @@ class BarnetrygdSøknadV10Validator {
                 }
             }
 
-            // Valider verdi - sjekk kun String-verdier
+            // Valider verdi - traverser rekursivt for å finne alle String-verdier
             søknadsfelt.verdi.forEach { (locale, verdi) ->
-                if (verdi is String && verdi.length > MAKS_LENGDE) {
-                    feil.add(
-                        Valideringsfeil(
-                            objectPath = "$objectPath.verdi",
-                            locale = locale,
-                            feilmelding = "Verdi overskrider maksimal lengde på $MAKS_LENGDE tegn (faktisk: ${verdi.length})",
-                        ),
-                    )
-                }
-
-                if (verdi is String && UGYLDIGE_TEGN_REGEX.containsMatchIn(verdi)) {
-                    feil.add(
-                        Valideringsfeil(
-                            objectPath = "$objectPath.verdi",
-                            locale = locale,
-                            feilmelding = "Verdi inneholder ugyldige tegn: $verdi",
-                        ),
-                    )
-                }
+                feil.addAll(validerVerdiRekursivt(verdi, "$objectPath.verdi", locale))
             }
 
             return feil

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
@@ -5,6 +5,7 @@ import no.nav.familie.kontrakter.ba.søknad.UGYLDIGE_TEGN_REGEX
 import no.nav.familie.kontrakter.ba.søknad.Valideringsfeil
 import no.nav.familie.kontrakter.ba.søknad.v4.Locale
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt
+import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelder
 import no.nav.familie.kontrakter.ba.søknad.v8.Omsorgsperson
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt as FellesSøknadsfelt
@@ -32,6 +33,11 @@ class BarnetrygdSøknadV10Validator {
                 localeMap.forEach { (locale, tekst) ->
                     feil.addAll(validerString(tekst, "teksterUtenomSpørsmål.$spørsmålId", locale))
                 }
+            }
+
+            // Valider dokumentasjon
+            søknad.dokumentasjon.forEachIndexed { index, dok ->
+                feil.addAll(validerDokumentasjon(dok, index))
             }
 
             return feil
@@ -160,12 +166,20 @@ class BarnetrygdSøknadV10Validator {
             andreForelder.fødselsdato?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.fødselsdato")) }
             andreForelder.arbeidUtlandet?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.arbeidUtlandet")) }
             andreForelder.pensjonUtland?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pensjonUtland")) }
-            andreForelder.skriftligAvtaleOmDeltBosted?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.skriftligAvtaleOmDeltBosted")) }
+            andreForelder.skriftligAvtaleOmDeltBosted?.let {
+                feil.addAll(
+                    validerFellesSøknadsfelt(it, "$baseSti.skriftligAvtaleOmDeltBosted"),
+                )
+            }
             andreForelder.pensjonNorge?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pensjonNorge")) }
             andreForelder.arbeidNorge?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.arbeidNorge")) }
             andreForelder.andreUtbetalinger?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.andreUtbetalinger")) }
             andreForelder.adresse?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.adresse")) }
-            andreForelder.pågåendeSøknadFraAnnetEøsLand?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pågåendeSøknadFraAnnetEøsLand")) }
+            andreForelder.pågåendeSøknadFraAnnetEøsLand?.let {
+                feil.addAll(
+                    validerFellesSøknadsfelt(it, "$baseSti.pågåendeSøknadFraAnnetEøsLand"),
+                )
+            }
             andreForelder.pågåendeSøknadHvilketLand?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.pågåendeSøknadHvilketLand")) }
             andreForelder.barnetrygdFraEøs?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.barnetrygdFraEøs")) }
 
@@ -212,7 +226,11 @@ class BarnetrygdSøknadV10Validator {
             // Enkeltfelt
             feil.addAll(validerFellesSøknadsfelt(omsorgsperson.navn, "$baseSti.navn"))
             feil.addAll(validerFellesSøknadsfelt(omsorgsperson.slektsforhold, "$baseSti.slektsforhold"))
-            omsorgsperson.slektsforholdSpesifisering?.let { feil.addAll(validerFellesSøknadsfelt(it, "$baseSti.slektsforholdSpesifisering")) }
+            omsorgsperson.slektsforholdSpesifisering?.let {
+                feil.addAll(
+                    validerFellesSøknadsfelt(it, "$baseSti.slektsforholdSpesifisering"),
+                )
+            }
             feil.addAll(validerFellesSøknadsfelt(omsorgsperson.idNummer, "$baseSti.idNummer"))
             feil.addAll(validerFellesSøknadsfelt(omsorgsperson.adresse, "$baseSti.adresse"))
             feil.addAll(validerFellesSøknadsfelt(omsorgsperson.arbeidUtland, "$baseSti.arbeidUtland"))
@@ -242,6 +260,29 @@ class BarnetrygdSøknadV10Validator {
             }
             omsorgsperson.eøsBarnetrygdsperioder.forEachIndexed { index, felt ->
                 feil.addAll(validerFellesSøknadsfelt(felt, "$baseSti.eøsBarnetrygdsperioder[$index]"))
+            }
+
+            return feil
+        }
+
+        private fun validerDokumentasjon(
+            dok: Søknaddokumentasjon,
+            index: Int,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+            val baseSti = "dokumentasjon[$index]"
+
+            // Valider dokumentasjonSpråkTittel
+            dok.dokumentasjonSpråkTittel.forEach { (locale, tittel) ->
+                feil.addAll(validerString(tittel, "$baseSti.dokumentasjonSpråkTittel", locale))
+            }
+
+            // Valider vedlegg
+            dok.opplastedeVedlegg.forEachIndexed { vedleggIndex, vedlegg ->
+                val vedleggSti = "$baseSti.opplastedeVedlegg[$vedleggIndex]"
+                // dokumentId har ingen locale, bruk tom string
+                feil.addAll(validerString(vedlegg.dokumentId, "$vedleggSti.dokumentId", ""))
+                feil.addAll(validerString(vedlegg.navn, "$vedleggSti.navn", ""))
             }
 
             return feil

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
@@ -9,6 +9,7 @@ import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelder
 import no.nav.familie.kontrakter.ba.søknad.v8.Omsorgsperson
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt as FellesSøknadsfelt
+import kotlin.reflect.full.memberProperties
 
 class BarnetrygdSøknadV10Validator {
     companion object {
@@ -332,6 +333,14 @@ class BarnetrygdSøknadV10Validator {
                     feil.addAll(validerString(verdi, objectPath, locale))
                 }
 
+                is FellesSøknadsfelt<*> -> {
+                    feil.addAll(validerFellesSøknadsfelt(verdi, objectPath))
+                }
+
+                is Søknadsfelt<*> -> {
+                    feil.addAll(validerSøknadsfelt(verdi, objectPath))
+                }
+
                 is Map<*, *> -> {
                     verdi.forEach { (key, value) ->
                         feil.addAll(validerVerdiRekursivt(value, "$objectPath.$key", locale))
@@ -341,6 +350,20 @@ class BarnetrygdSøknadV10Validator {
                 is Collection<*> -> {
                     verdi.forEachIndexed { index, element ->
                         feil.addAll(validerVerdiRekursivt(element, "$objectPath[$index]", locale))
+                    }
+                }
+
+                else -> {
+                    // Refleksjon: traverser feltene i ukjente objekter (f.eks. Utbetalingsperiode, Arbeidsperiode, etc.)
+                    verdi::class.memberProperties.forEach { prop ->
+                        try {
+                            val feltVerdi = prop.getter.call(verdi)
+                            if (feltVerdi != null) {
+                                feil.addAll(validerVerdiRekursivt(feltVerdi, "$objectPath.${prop.name}", locale))
+                            }
+                        } catch (_: Exception) {
+                            // Ignorer felt som ikke kan leses
+                        }
                     }
                 }
             }

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
@@ -8,8 +8,8 @@ import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt
 import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelder
 import no.nav.familie.kontrakter.ba.søknad.v8.Omsorgsperson
-import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt as FellesSøknadsfelt
 import kotlin.reflect.full.memberProperties
+import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt as FellesSøknadsfelt
 
 class BarnetrygdSøknadV10Validator {
     companion object {

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10ValidatorTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10ValidatorTest.kt
@@ -918,6 +918,154 @@ class BarnetrygdSøknadV10ValidatorTest {
         assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
     }
 
+    // --- Tester for refleksjonsbasert traversering av indre objekter ---
+
+    @Test
+    fun `valider skal finne ugyldig label inne i Utbetalingsperiode via refleksjon`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        andreUtbetalingsperioder =
+                            listOf(
+                                FellesSøknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                Utbetalingsperiode(
+                                                    fårUtbetalingNå = FellesSøknadsfelt(label = mapOf("nb" to langStreng), verdi = mapOf("nb" to "JA")),
+                                                    utbetalingLand = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige")),
+                                                    utbetalingFraDato = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
+                                                    utbetalingTilDato = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2021-01-01")),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Forventet valideringsfeil for ugyldig label i Utbetalingsperiode")
+        assertTrue(feil.any { it.feilmelding.contains("Label overskrider maksimal lengde") })
+    }
+
+    @Test
+    fun `valider skal finne ugyldig verdi inne i Arbeidsperiode via refleksjon`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        arbeidsperioderUtland =
+                            listOf(
+                                FellesSøknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                Arbeidsperiode(
+                                                    arbeidsgiver = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Forventet valideringsfeil for ugyldig verdi i Arbeidsperiode")
+        assertTrue(feil.any { it.feilmelding.contains("Verdi overskrider maksimal lengde") })
+    }
+
+    @Test
+    fun `valider skal finne ugyldige tegn inne i Pensjonsperiode via refleksjon`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        pensjonsperioderUtland =
+                            listOf(
+                                FellesSøknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                Pensjonsperiode(
+                                                    pensjonsland = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige<script>")),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Forventet valideringsfeil for ugyldige tegn i Pensjonsperiode")
+        assertTrue(feil.any { it.feilmelding.contains("ugyldige tegn") })
+    }
+
+    @Test
+    fun `valider skal finne ugyldig felt inne i EøsBarnetrygdsperiode via refleksjon`() {
+        val barn =
+            lagGyldigBarn().copy(
+                eøsBarnetrygdsperioder =
+                    listOf(
+                        FellesSøknadsfelt(
+                            label = gyldigLabel,
+                            verdi =
+                                mapOf(
+                                    "nb" to
+                                        EøsBarnetrygdsperiode(
+                                            barnetrygdsland = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Danmark")),
+                                            fraDatoBarnetrygdperiode = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
+                                            månedligBeløp = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                                        ),
+                        ),
+                    ),
+                ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Forventet valideringsfeil for ugyldig felt i EøsBarnetrygdsperiode")
+        assertTrue(feil.any { it.feilmelding.contains("Verdi overskrider maksimal lengde") })
+    }
+
+    @Test
+    fun `valider skal ikke gi feil for gyldige verdier inne i periodeobjekter`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        arbeidsperioderUtland =
+                            listOf(
+                                FellesSøknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                Arbeidsperiode(
+                                                    arbeidsperiodeAvsluttet = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "JA")),
+                                                    arbeidsperiodeland = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige")),
+                                                    arbeidsgiver = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "IKEA")),
+                                                    fraDatoArbeidsperiode = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
+                                                    tilDatoArbeidsperiode = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2021-01-01")),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty(), "Forventet ingen feil for gyldige verdier i Arbeidsperiode")
+    }
+
     private fun lagGyldigSøknad() =
         BarnetrygdSøknad(
             kontraktVersjon = 10,

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10ValidatorTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10ValidatorTest.kt
@@ -5,6 +5,16 @@ import no.nav.familie.kontrakter.ba.søknad.v1.SøknadAdresse
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
 import no.nav.familie.kontrakter.ba.søknad.v5.RegistrertBostedType
+import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
+import no.nav.familie.kontrakter.ba.søknad.v7.Dokumentasjonsbehov
+import no.nav.familie.kontrakter.ba.søknad.v7.Søknadsvedlegg
+import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelder
+import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelderUtvidet
+import no.nav.familie.kontrakter.ba.søknad.v8.Arbeidsperiode
+import no.nav.familie.kontrakter.ba.søknad.v8.EøsBarnetrygdsperiode
+import no.nav.familie.kontrakter.ba.søknad.v8.Omsorgsperson
+import no.nav.familie.kontrakter.ba.søknad.v8.Pensjonsperiode
+import no.nav.familie.kontrakter.ba.søknad.v8.Utbetalingsperiode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -422,6 +432,492 @@ class BarnetrygdSøknadV10ValidatorTest {
         assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
     }
 
+    // --- Tester for teksterUtenomSpørsmål ---
+
+    @Test
+    fun `valider skal returnere feil når teksterUtenomSpørsmål har for lang streng`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                teksterUtenomSpørsmål =
+                    mapOf(
+                        "tekst1" to mapOf("nb" to langStreng),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("teksterUtenomSpørsmål.tekst1", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når teksterUtenomSpørsmål inneholder ugyldige tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                teksterUtenomSpørsmål =
+                    mapOf(
+                        "tekst1" to mapOf("nb" to "Test<script>alert</script>"),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("teksterUtenomSpørsmål.tekst1", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil for flere locales i teksterUtenomSpørsmål`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                teksterUtenomSpørsmål =
+                    mapOf(
+                        "tekst1" to mapOf("nb" to langStreng, "nn" to langStreng),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(2, feil.size)
+        assertTrue(feil.any { it.locale == "nb" })
+        assertTrue(feil.any { it.locale == "nn" })
+    }
+
+    // --- Tester for dokumentasjon ---
+
+    @Test
+    fun `valider skal returnere feil når dokumentasjon språktittel er for lang`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg = emptyList(),
+                            dokumentasjonSpråkTittel = mapOf("nb" to langStreng),
+                        ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].dokumentasjonSpråkTittel", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når dokumentasjon språktittel inneholder ugyldige tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg = emptyList(),
+                            dokumentasjonSpråkTittel = mapOf("nb" to "Tittel med <html>"),
+                        ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].dokumentasjonSpråkTittel", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når vedlegg navn er for langt`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg =
+                                listOf(
+                                    Søknadsvedlegg(
+                                        dokumentId = "dok-123",
+                                        navn = langStreng,
+                                        tittel = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                                    ),
+                                ),
+                            dokumentasjonSpråkTittel = mapOf("nb" to "Gyldig tittel"),
+                        ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].opplastedeVedlegg[0].navn", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når vedlegg navn inneholder ugyldige tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg =
+                                listOf(
+                                    Søknadsvedlegg(
+                                        dokumentId = "dok-123",
+                                        navn = "fil<script>.pdf",
+                                        tittel = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                                    ),
+                                ),
+                            dokumentasjonSpråkTittel = mapOf("nb" to "Gyldig tittel"),
+                        ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].opplastedeVedlegg[0].navn", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når vedlegg dokumentId er for lang`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg =
+                                listOf(
+                                    Søknadsvedlegg(
+                                        dokumentId = langStreng,
+                                        navn = "gyldig-fil.pdf",
+                                        tittel = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                                    ),
+                                ),
+                            dokumentasjonSpråkTittel = mapOf("nb" to "Gyldig tittel"),
+                        ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].opplastedeVedlegg[0].dokumentId", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    // --- Tester for andreForelder ---
+
+    @Test
+    fun `valider skal returnere feil når andreForelder har ugyldig felt`() {
+        val barn =
+            lagGyldigBarn().copy(
+                andreForelder =
+                    lagGyldigAndreForelder().copy(
+                        navn = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].andreForelder.navn.verdi", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når andreForelder label inneholder ugyldige tegn`() {
+        val barn =
+            lagGyldigBarn().copy(
+                andreForelder =
+                    lagGyldigAndreForelder().copy(
+                        kanIkkeGiOpplysninger =
+                            FellesSøknadsfelt(
+                                label = mapOf("nb" to "Test<>verdi"),
+                                verdi = mapOf("nb" to "NEI"),
+                            ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].andreForelder.kanIkkeGiOpplysninger.label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når andreForelder liste-element har ugyldig felt`() {
+        val barn =
+            lagGyldigBarn().copy(
+                andreForelder =
+                    lagGyldigAndreForelder().copy(
+                        arbeidsperioderUtland =
+                            listOf(
+                                FellesSøknadsfelt(
+                                    label = mapOf("nb" to langStreng),
+                                    verdi = mapOf("nb" to Arbeidsperiode()),
+                                ),
+                            ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].andreForelder.arbeidsperioderUtland[0].label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Label overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når andreForelder utvidet har ugyldig felt`() {
+        val barn =
+            lagGyldigBarn().copy(
+                andreForelder =
+                    lagGyldigAndreForelder().copy(
+                        utvidet =
+                            AndreForelderUtvidet(
+                                søkerHarBoddMedAndreForelder =
+                                    FellesSøknadsfelt(
+                                        label = gyldigLabel,
+                                        verdi = mapOf("nb" to langStreng),
+                                    ),
+                            ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].andreForelder.utvidet.søkerHarBoddMedAndreForelder.verdi", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal ikke returnere feil når andreForelder er null`() {
+        val barn = lagGyldigBarn().copy(andreForelder = null)
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty())
+    }
+
+    // --- Tester for omsorgsperson ---
+
+    @Test
+    fun `valider skal returnere feil når omsorgsperson har ugyldig felt`() {
+        val barn =
+            lagGyldigBarn().copy(
+                omsorgsperson =
+                    lagGyldigOmsorgsperson().copy(
+                        navn = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].omsorgsperson.navn.verdi", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når omsorgsperson label inneholder ugyldige tegn`() {
+        val barn =
+            lagGyldigBarn().copy(
+                omsorgsperson =
+                    lagGyldigOmsorgsperson().copy(
+                        slektsforhold =
+                            FellesSøknadsfelt(
+                                label = mapOf("nb" to "Test<>verdi"),
+                                verdi = mapOf("nb" to "FORELDER"),
+                            ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].omsorgsperson.slektsforhold.label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når omsorgsperson liste-element har ugyldig felt`() {
+        val barn =
+            lagGyldigBarn().copy(
+                omsorgsperson =
+                    lagGyldigOmsorgsperson().copy(
+                        pensjonsperioderNorge =
+                            listOf(
+                                FellesSøknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi = mapOf("nb" to Pensjonsperiode()),
+                                ),
+                                FellesSøknadsfelt(
+                                    label = mapOf("nb" to langStreng),
+                                    verdi = mapOf("nb" to Pensjonsperiode()),
+                                ),
+                            ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].omsorgsperson.pensjonsperioderNorge[1].label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Label overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal ikke returnere feil når omsorgsperson er null`() {
+        val barn = lagGyldigBarn().copy(omsorgsperson = null)
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty())
+    }
+
+    // --- Tester for rekursiv validering av Any-verdier ---
+
+    @Test
+    fun `valider skal finne ugyldige strenger i Map-verdier via rekursiv traversering`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        spørsmål =
+                            mapOf(
+                                "nestedMap" to
+                                    FellesSøknadsfelt(
+                                        label = gyldigLabel,
+                                        verdi = mapOf("nb" to mapOf("innerKey" to langStreng)),
+                                    ),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.spørsmål.nestedMap.verdi.innerKey", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal finne ugyldige strenger i List-verdier via rekursiv traversering`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        spørsmål =
+                            mapOf(
+                                "nestedList" to
+                                    FellesSøknadsfelt(
+                                        label = gyldigLabel,
+                                        verdi = mapOf("nb" to listOf("gyldig", langStreng)),
+                                    ),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.spørsmål.nestedList.verdi[1]", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal finne ugyldige tegn i nestede strukturer via rekursiv traversering`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        spørsmål =
+                            mapOf(
+                                "deepNested" to
+                                    FellesSøknadsfelt(
+                                        label = gyldigLabel,
+                                        verdi = mapOf("nb" to mapOf("level1" to listOf("ok", "test<xss>"))),
+                                    ),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.spørsmål.deepNested.verdi.level1[1]", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal ignorere non-string verdier i nestede strukturer`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        spørsmål =
+                            mapOf(
+                                "mixed" to
+                                    FellesSøknadsfelt(
+                                        label = gyldigLabel,
+                                        verdi = mapOf("nb" to mapOf("bool" to true, "int" to 42, "str" to "gyldig")),
+                                    ),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty(), "Non-string verdier i nestede strukturer skal ikke forårsake feil")
+    }
+
+    @Test
+    fun `valider skal finne ugyldige strenger i v4 Søknadsfelt med nestede Map-verdier`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                spørsmål =
+                    mapOf(
+                        "nestedSpørsmål" to
+                            Søknadsfelt(
+                                label = gyldigLabel,
+                                verdi = mapOf("nb" to mapOf("key" to "ugyldig<verdi")),
+                            ),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("spørsmål.nestedSpørsmål.verdi.key", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
     private fun lagGyldigSøknad() =
         BarnetrygdSøknad(
             kontraktVersjon = 10,
@@ -474,5 +970,28 @@ class BarnetrygdSøknadV10ValidatorTest {
                     verdi = mapOf("nb" to RegistrertBostedType.REGISTRERT_SOKERS_ADRESSE),
                 ),
             spørsmål = emptyMap(),
+        )
+
+    private fun lagGyldigAndreForelder() =
+        AndreForelder(
+            kanIkkeGiOpplysninger = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            navn = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Ola Nordmann")),
+            fnr = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "12345678910")),
+            utvidet = AndreForelderUtvidet(),
+        )
+
+    private fun lagGyldigOmsorgsperson() =
+        Omsorgsperson(
+            navn = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Kari Nordmann")),
+            slektsforhold = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "FORELDER")),
+            idNummer = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "12345678910")),
+            adresse = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Testveien 1")),
+            arbeidUtland = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            arbeidNorge = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "JA")),
+            pensjonUtland = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            pensjonNorge = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            andreUtbetalinger = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            pågåendeSøknadFraAnnetEøsLand = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            barnetrygdFraEøs = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
         )
 }

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10ValidatorTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10ValidatorTest.kt
@@ -5,8 +5,8 @@ import no.nav.familie.kontrakter.ba.søknad.v1.SøknadAdresse
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadsfelt
 import no.nav.familie.kontrakter.ba.søknad.v4.Søknadstype
 import no.nav.familie.kontrakter.ba.søknad.v5.RegistrertBostedType
-import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v7.Dokumentasjonsbehov
+import no.nav.familie.kontrakter.ba.søknad.v7.Søknaddokumentasjon
 import no.nav.familie.kontrakter.ba.søknad.v7.Søknadsvedlegg
 import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelder
 import no.nav.familie.kontrakter.ba.søknad.v8.AndreForelderUtvidet
@@ -934,10 +934,29 @@ class BarnetrygdSøknadV10ValidatorTest {
                                         mapOf(
                                             "nb" to
                                                 Utbetalingsperiode(
-                                                    fårUtbetalingNå = FellesSøknadsfelt(label = mapOf("nb" to langStreng), verdi = mapOf("nb" to "JA")),
-                                                    utbetalingLand = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige")),
-                                                    utbetalingFraDato = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
-                                                    utbetalingTilDato = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2021-01-01")),
+                                                    fårUtbetalingNå =
+                                                        FellesSøknadsfelt(
+                                                            label = mapOf("nb" to langStreng),
+                                                            verdi =
+                                                                mapOf("nb" to "JA"),
+                                                        ),
+                                                    utbetalingLand =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi = mapOf("nb" to "Sverige"),
+                                                        ),
+                                                    utbetalingFraDato =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi =
+                                                                mapOf("nb" to "2020-01-01"),
+                                                        ),
+                                                    utbetalingTilDato =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi =
+                                                                mapOf("nb" to "2021-01-01"),
+                                                        ),
                                                 ),
                                         ),
                                 ),
@@ -965,7 +984,11 @@ class BarnetrygdSøknadV10ValidatorTest {
                                         mapOf(
                                             "nb" to
                                                 Arbeidsperiode(
-                                                    arbeidsgiver = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                                                    arbeidsgiver =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi = mapOf("nb" to langStreng),
+                                                        ),
                                                 ),
                                         ),
                                 ),
@@ -993,7 +1016,12 @@ class BarnetrygdSøknadV10ValidatorTest {
                                         mapOf(
                                             "nb" to
                                                 Pensjonsperiode(
-                                                    pensjonsland = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige<script>")),
+                                                    pensjonsland =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi =
+                                                                mapOf("nb" to "Sverige<script>"),
+                                                        ),
                                                 ),
                                         ),
                                 ),
@@ -1020,12 +1048,17 @@ class BarnetrygdSøknadV10ValidatorTest {
                                     "nb" to
                                         EøsBarnetrygdsperiode(
                                             barnetrygdsland = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Danmark")),
-                                            fraDatoBarnetrygdperiode = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
+                                            fraDatoBarnetrygdperiode =
+                                                FellesSøknadsfelt(
+                                                    label = gyldigLabel,
+                                                    verdi =
+                                                        mapOf("nb" to "2020-01-01"),
+                                                ),
                                             månedligBeløp = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
                                         ),
+                                ),
                         ),
                     ),
-                ),
             )
         val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
 
@@ -1049,11 +1082,35 @@ class BarnetrygdSøknadV10ValidatorTest {
                                         mapOf(
                                             "nb" to
                                                 Arbeidsperiode(
-                                                    arbeidsperiodeAvsluttet = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "JA")),
-                                                    arbeidsperiodeland = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige")),
-                                                    arbeidsgiver = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "IKEA")),
-                                                    fraDatoArbeidsperiode = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
-                                                    tilDatoArbeidsperiode = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2021-01-01")),
+                                                    arbeidsperiodeAvsluttet =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi =
+                                                                mapOf("nb" to "JA"),
+                                                        ),
+                                                    arbeidsperiodeland =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi =
+                                                                mapOf("nb" to "Sverige"),
+                                                        ),
+                                                    arbeidsgiver =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi = mapOf("nb" to "IKEA"),
+                                                        ),
+                                                    fraDatoArbeidsperiode =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi =
+                                                                mapOf("nb" to "2020-01-01"),
+                                                        ),
+                                                    tilDatoArbeidsperiode =
+                                                        FellesSøknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi =
+                                                                mapOf("nb" to "2021-01-01"),
+                                                        ),
                                                 ),
                                         ),
                                 ),

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <name>Kontrakter for familieytelsene</name>
 
     <properties>
-        <revision>4.100</revision>
+        <revision>4.0</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
NAV-23039

Mer validering av søknadskontrakten for Barnetrygd. Lagt på validering på String i input
- Valideringskoden i dag manglet en del validering.
- Validering av input man ikke nødvendigvis vet objektet på ved bruk av reflection

Den er en utvidelse av https://github.com/navikt/familie-kontrakter/pull/1106
