### PR TITLE
Validering av Kontantstøtte-kontrakt

### DIFF
--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/Valideringsfeil.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/Valideringsfeil.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.kontrakter.ks.søknad
+
+import no.nav.familie.kontrakter.ks.søknad.v1.Locale
+
+/**
+ * Representerer valideringsfeil i søknaden.
+ *
+ * @param objectPath Sti til objektet som feilet validering
+ * @param locale Språket til verdien som feilet validering
+ * @param feilmelding Beskrivelse av valideringsfeilen
+ */
+data class Valideringsfeil(
+    val objectPath: String,
+    val locale: Locale,
+    val feilmelding: String,
+)
+
+const val MAKS_LENGDE = 200
+val UGYLDIGE_TEGN_REGEX = Regex("[<>\"]")

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v6/KontantstøtteSøknadV6Validator.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v6/KontantstøtteSøknadV6Validator.kt
@@ -1,0 +1,422 @@
+package no.nav.familie.kontrakter.ks.søknad.v6
+
+import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
+import no.nav.familie.kontrakter.ks.søknad.MAKS_LENGDE
+import no.nav.familie.kontrakter.ks.søknad.UGYLDIGE_TEGN_REGEX
+import no.nav.familie.kontrakter.ks.søknad.Valideringsfeil
+import no.nav.familie.kontrakter.ks.søknad.v1.Locale
+import no.nav.familie.kontrakter.ks.søknad.v1.Søknaddokumentasjon
+import no.nav.familie.kontrakter.ks.søknad.v2.Omsorgsperson
+import no.nav.familie.kontrakter.ks.søknad.v4.AndreForelder
+import no.nav.familie.kontrakter.ks.søknad.v4.Søker
+import kotlin.reflect.full.memberProperties
+
+class KontantstøtteSøknadV6Validator {
+    companion object {
+        fun valider(søknad: KontantstøtteSøknad): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            // Valider søker
+            feil.addAll(validerSøker(søknad.søker))
+
+            // Valider barn
+            søknad.barn.forEachIndexed { index, barn ->
+                feil.addAll(validerBarn(barn, index))
+            }
+
+            // Valider toppnivå Søknadsfelt-felter
+            feil.addAll(validerSøknadsfelt(søknad.erNoenAvBarnaFosterbarn, "erNoenAvBarnaFosterbarn"))
+            feil.addAll(validerSøknadsfelt(søknad.søktAsylForBarn, "søktAsylForBarn"))
+            feil.addAll(validerSøknadsfelt(søknad.oppholderBarnSegIInstitusjon, "oppholderBarnSegIInstitusjon"))
+            feil.addAll(validerSøknadsfelt(søknad.barnOppholdtSegTolvMndSammenhengendeINorge, "barnOppholdtSegTolvMndSammenhengendeINorge"))
+            feil.addAll(validerSøknadsfelt(søknad.erBarnAdoptert, "erBarnAdoptert"))
+            feil.addAll(validerSøknadsfelt(søknad.mottarKontantstøtteForBarnFraAnnetEøsland, "mottarKontantstøtteForBarnFraAnnetEøsland"))
+            feil.addAll(validerSøknadsfelt(søknad.harEllerTildeltBarnehageplass, "harEllerTildeltBarnehageplass"))
+            søknad.erAvdødPartnerForelder?.let {
+                feil.addAll(validerSøknadsfelt(it, "erAvdødPartnerForelder"))
+            }
+
+            // Valider teksterTilPdf
+            søknad.teksterTilPdf.forEach { (key, tekstPåSpråkMap) ->
+                tekstPåSpråkMap.forEach { (locale, tekst) ->
+                    feil.addAll(validerString(tekst, "teksterTilPdf.$key", locale))
+                }
+            }
+
+            // Valider dokumentasjon
+            søknad.dokumentasjon.forEachIndexed { index, dok ->
+                feil.addAll(validerDokumentasjon(dok, index))
+            }
+
+            return feil
+        }
+
+        private fun validerSøker(søker: Søker): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            // Valider Søknadsfelt-felter
+            feil.addAll(validerSøknadsfelt(søker.ident, "søker.ident"))
+            feil.addAll(validerSøknadsfelt(søker.navn, "søker.navn"))
+            feil.addAll(validerSøknadsfelt(søker.statsborgerskap, "søker.statsborgerskap"))
+            feil.addAll(validerSøknadsfelt(søker.adresse, "søker.adresse"))
+            feil.addAll(validerSøknadsfelt(søker.sivilstand, "søker.sivilstand"))
+
+            // Enkeltfelter
+            søker.borPåRegistrertAdresse?.let { feil.addAll(validerSøknadsfelt(it, "søker.borPåRegistrertAdresse")) }
+            feil.addAll(validerSøknadsfelt(søker.værtINorgeITolvMåneder, "søker.værtINorgeITolvMåneder"))
+            feil.addAll(validerSøknadsfelt(søker.planleggerÅBoINorgeTolvMnd, "søker.planleggerÅBoINorgeTolvMnd"))
+            feil.addAll(validerSøknadsfelt(søker.yrkesaktivFemÅr, "søker.yrkesaktivFemÅr"))
+            feil.addAll(validerSøknadsfelt(søker.erAsylsøker, "søker.erAsylsøker"))
+            feil.addAll(validerSøknadsfelt(søker.utenlandsoppholdUtenArbeid, "søker.utenlandsoppholdUtenArbeid"))
+            feil.addAll(validerSøknadsfelt(søker.arbeidIUtlandet, "søker.arbeidIUtlandet"))
+            feil.addAll(validerSøknadsfelt(søker.mottarUtenlandspensjon, "søker.mottarUtenlandspensjon"))
+            søker.arbeidINorge?.let { feil.addAll(validerSøknadsfelt(it, "søker.arbeidINorge")) }
+            søker.pensjonNorge?.let { feil.addAll(validerSøknadsfelt(it, "søker.pensjonNorge")) }
+            søker.andreUtbetalinger?.let { feil.addAll(validerSøknadsfelt(it, "søker.andreUtbetalinger")) }
+            søker.adresseISøkeperiode?.let { feil.addAll(validerSøknadsfelt(it, "søker.adresseISøkeperiode")) }
+
+            // Lister
+            søker.utenlandsperioder.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "søker.utenlandsperioder[$index]"))
+            }
+            søker.arbeidsperioderUtland.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "søker.arbeidsperioderUtland[$index]"))
+            }
+            søker.pensjonsperioderUtland.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "søker.pensjonsperioderUtland[$index]"))
+            }
+            søker.arbeidsperioderNorge.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "søker.arbeidsperioderNorge[$index]"))
+            }
+            søker.pensjonsperioderNorge.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "søker.pensjonsperioderNorge[$index]"))
+            }
+            søker.andreUtbetalingsperioder.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "søker.andreUtbetalingsperioder[$index]"))
+            }
+            søker.idNummer.forEachIndexed { index, idNummer ->
+                feil.addAll(validerSøknadsfelt(idNummer, "søker.idNummer[$index]"))
+            }
+
+            return feil
+        }
+
+        private fun validerBarn(
+            barn: Barn,
+            barnIndex: Int,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+            val baseSti = "barn[$barnIndex]"
+
+            // Valider Søknadsfelt-felter
+            feil.addAll(validerSøknadsfelt(barn.ident, "$baseSti.ident"))
+            feil.addAll(validerSøknadsfelt(barn.navn, "$baseSti.navn"))
+            feil.addAll(validerSøknadsfelt(barn.registrertBostedType, "$baseSti.registrertBostedType"))
+            barn.alder?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.alder")) }
+
+            // Om Barna
+            feil.addAll(validerSøknadsfelt(barn.erFosterbarn, "$baseSti.erFosterbarn"))
+            feil.addAll(validerSøknadsfelt(barn.oppholderSegIInstitusjon, "$baseSti.oppholderSegIInstitusjon"))
+            feil.addAll(validerSøknadsfelt(barn.erAdoptert, "$baseSti.erAdoptert"))
+            feil.addAll(validerSøknadsfelt(barn.erAsylsøker, "$baseSti.erAsylsøker"))
+            feil.addAll(validerSøknadsfelt(barn.boddMindreEnn12MndINorge, "$baseSti.boddMindreEnn12MndINorge"))
+            feil.addAll(validerSøknadsfelt(barn.kontantstøtteFraAnnetEøsland, "$baseSti.kontantstøtteFraAnnetEøsland"))
+            feil.addAll(validerSøknadsfelt(barn.harBarnehageplass, "$baseSti.harBarnehageplass"))
+            barn.andreForelderErDød?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.andreForelderErDød")) }
+
+            // Om barnet - oppfølgningsspørsmål
+            barn.utbetaltForeldrepengerEllerEngangsstønad?.let {
+                feil.addAll(validerSøknadsfelt(it, "$baseSti.utbetaltForeldrepengerEllerEngangsstønad"))
+            }
+            barn.mottarEllerMottokEøsKontantstøtte?.let {
+                feil.addAll(
+                    validerSøknadsfelt(it, "$baseSti.mottarEllerMottokEøsKontantstøtte"),
+                )
+            }
+            barn.pågåendeSøknadFraAnnetEøsLand?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.pågåendeSøknadFraAnnetEøsLand")) }
+            barn.pågåendeSøknadHvilketLand?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.pågåendeSøknadHvilketLand")) }
+            barn.planleggerÅBoINorge12Mnd?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.planleggerÅBoINorge12Mnd")) }
+
+            // Perioder
+            barn.eøsKontantstøttePerioder.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "$baseSti.eøsKontantstøttePerioder[$index]"))
+            }
+            barn.barnehageplassPerioder.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "$baseSti.barnehageplassPerioder[$index]"))
+            }
+            barn.utenlandsperioder.forEachIndexed { index, periode ->
+                feil.addAll(validerSøknadsfelt(periode, "$baseSti.utenlandsperioder[$index]"))
+            }
+            barn.idNummer.forEachIndexed { index, idNummer ->
+                feil.addAll(validerSøknadsfelt(idNummer, "$baseSti.idNummer[$index]"))
+            }
+
+            // Om barnet
+            feil.addAll(validerSøknadsfelt(barn.borFastMedSøker, "$baseSti.borFastMedSøker"))
+            barn.foreldreBorSammen?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.foreldreBorSammen")) }
+            barn.søkerDeltKontantstøtte?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.søkerDeltKontantstøtte")) }
+
+            // EØS
+            barn.søkersSlektsforhold?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.søkersSlektsforhold")) }
+            barn.søkersSlektsforholdSpesifisering?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.søkersSlektsforholdSpesifisering")) }
+            barn.borMedAndreForelder?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.borMedAndreForelder")) }
+            barn.borMedOmsorgsperson?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.borMedOmsorgsperson")) }
+            barn.adresse?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.adresse")) }
+
+            // Valider andreForelder
+            barn.andreForelder?.let {
+                feil.addAll(validerAndreForelder(it, "$baseSti.andreForelder"))
+            }
+
+            // Valider omsorgsperson
+            barn.omsorgsperson?.let {
+                feil.addAll(validerOmsorgsperson(it, "$baseSti.omsorgsperson"))
+            }
+
+            // Valider teksterTilPdf
+            barn.teksterTilPdf.forEach { (key, tekstPåSpråkMap) ->
+                tekstPåSpråkMap.forEach { (locale, tekst) ->
+                    feil.addAll(validerString(tekst, "$baseSti.teksterTilPdf.$key", locale))
+                }
+            }
+
+            return feil
+        }
+
+        private fun validerAndreForelder(
+            andreForelder: AndreForelder,
+            baseSti: String,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            // Enkeltfelt
+            feil.addAll(validerSøknadsfelt(andreForelder.kanIkkeGiOpplysninger, "$baseSti.kanIkkeGiOpplysninger"))
+            andreForelder.navn?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.navn")) }
+            andreForelder.fnr?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.fnr")) }
+            andreForelder.fødselsdato?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.fødselsdato")) }
+            andreForelder.yrkesaktivFemÅr?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.yrkesaktivFemÅr")) }
+            andreForelder.arbeidUtlandet?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.arbeidUtlandet")) }
+            andreForelder.utenlandsoppholdUtenArbeid?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.utenlandsoppholdUtenArbeid")) }
+            andreForelder.pensjonUtland?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.pensjonUtland")) }
+            andreForelder.arbeidNorge?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.arbeidNorge")) }
+            andreForelder.pensjonNorge?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.pensjonNorge")) }
+            andreForelder.andreUtbetalinger?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.andreUtbetalinger")) }
+            andreForelder.adresse?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.adresse")) }
+            andreForelder.pågåendeSøknadFraAnnetEøsLand?.let {
+                feil.addAll(
+                    validerSøknadsfelt(it, "$baseSti.pågåendeSøknadFraAnnetEøsLand"),
+                )
+            }
+            andreForelder.pågåendeSøknadHvilketLand?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.pågåendeSøknadHvilketLand")) }
+            andreForelder.kontantstøtteFraEøs?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.kontantstøtteFraEøs")) }
+
+            // Lister
+            andreForelder.arbeidsperioderUtland.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.arbeidsperioderUtland[$index]"))
+            }
+            andreForelder.pensjonsperioderUtland.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.pensjonsperioderUtland[$index]"))
+            }
+            andreForelder.arbeidsperioderNorge.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.arbeidsperioderNorge[$index]"))
+            }
+            andreForelder.pensjonsperioderNorge.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.pensjonsperioderNorge[$index]"))
+            }
+            andreForelder.andreUtbetalingsperioder.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.andreUtbetalingsperioder[$index]"))
+            }
+            andreForelder.eøsKontantstøttePerioder.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.eøsKontantstøttePerioder[$index]"))
+            }
+            andreForelder.utenlandsperioder.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.utenlandsperioder[$index]"))
+            }
+            andreForelder.idNummer.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.idNummer[$index]"))
+            }
+
+            return feil
+        }
+
+        private fun validerOmsorgsperson(
+            omsorgsperson: Omsorgsperson,
+            baseSti: String,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            // Enkeltfelt
+            feil.addAll(validerSøknadsfelt(omsorgsperson.navn, "$baseSti.navn"))
+            omsorgsperson.slektsforhold?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.slektsforhold")) }
+            omsorgsperson.slektsforholdSpesifisering?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.slektsforholdSpesifisering")) }
+            feil.addAll(validerSøknadsfelt(omsorgsperson.idNummer, "$baseSti.idNummer"))
+            feil.addAll(validerSøknadsfelt(omsorgsperson.adresse, "$baseSti.adresse"))
+            feil.addAll(validerSøknadsfelt(omsorgsperson.arbeidUtland, "$baseSti.arbeidUtland"))
+            feil.addAll(validerSøknadsfelt(omsorgsperson.arbeidNorge, "$baseSti.arbeidNorge"))
+            feil.addAll(validerSøknadsfelt(omsorgsperson.pensjonUtland, "$baseSti.pensjonUtland"))
+            feil.addAll(validerSøknadsfelt(omsorgsperson.pensjonNorge, "$baseSti.pensjonNorge"))
+            feil.addAll(validerSøknadsfelt(omsorgsperson.andreUtbetalinger, "$baseSti.andreUtbetalinger"))
+            feil.addAll(validerSøknadsfelt(omsorgsperson.pågåendeSøknadFraAnnetEøsLand, "$baseSti.pågåendeSøknadFraAnnetEøsLand"))
+            omsorgsperson.pågåendeSøknadHvilketLand?.let { feil.addAll(validerSøknadsfelt(it, "$baseSti.pågåendeSøknadHvilketLand")) }
+            feil.addAll(validerSøknadsfelt(omsorgsperson.kontantstøtteFraEøs, "$baseSti.kontantstøtteFraEøs"))
+
+            // Lister
+            omsorgsperson.arbeidsperioderUtland.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.arbeidsperioderUtland[$index]"))
+            }
+            omsorgsperson.arbeidsperioderNorge.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.arbeidsperioderNorge[$index]"))
+            }
+            omsorgsperson.pensjonsperioderUtland.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.pensjonsperioderUtland[$index]"))
+            }
+            omsorgsperson.pensjonsperioderNorge.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.pensjonsperioderNorge[$index]"))
+            }
+            omsorgsperson.andreUtbetalingsperioder.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.andreUtbetalingsperioder[$index]"))
+            }
+            omsorgsperson.eøsKontantstøttePerioder.forEachIndexed { index, felt ->
+                feil.addAll(validerSøknadsfelt(felt, "$baseSti.eøsKontantstøttePerioder[$index]"))
+            }
+
+            return feil
+        }
+
+        private fun validerDokumentasjon(
+            dok: Søknaddokumentasjon,
+            index: Int,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+            val baseSti = "dokumentasjon[$index]"
+
+            // Valider dokumentasjonSpråkTittel
+            dok.dokumentasjonSpråkTittel.forEach { (locale, tittel) ->
+                feil.addAll(validerString(tittel, "$baseSti.dokumentasjonSpråkTittel", locale))
+            }
+
+            // Valider vedlegg
+            dok.opplastedeVedlegg.forEachIndexed { vedleggIndex, vedlegg ->
+                val vedleggSti = "$baseSti.opplastedeVedlegg[$vedleggIndex]"
+                feil.addAll(validerString(vedlegg.dokumentId, "$vedleggSti.dokumentId", ""))
+                feil.addAll(validerString(vedlegg.navn, "$vedleggSti.navn", ""))
+            }
+
+            return feil
+        }
+
+        private fun validerString(
+            verdi: String,
+            objectPath: String,
+            locale: Locale,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            if (verdi.length > MAKS_LENGDE) {
+                feil.add(
+                    Valideringsfeil(
+                        objectPath = objectPath,
+                        locale = locale,
+                        feilmelding = "Verdi overskrider maksimal lengde på $MAKS_LENGDE tegn (faktisk: ${verdi.length})",
+                    ),
+                )
+            }
+
+            if (UGYLDIGE_TEGN_REGEX.containsMatchIn(verdi)) {
+                feil.add(
+                    Valideringsfeil(
+                        objectPath = objectPath,
+                        locale = locale,
+                        feilmelding = "Verdi inneholder ugyldige tegn: $verdi",
+                    ),
+                )
+            }
+
+            return feil
+        }
+
+        private fun validerVerdiRekursivt(
+            verdi: Any?,
+            objectPath: String,
+            locale: Locale,
+        ): List<Valideringsfeil> {
+            if (verdi == null) return emptyList()
+
+            val feil = mutableListOf<Valideringsfeil>()
+
+            when (verdi) {
+                is String -> {
+                    feil.addAll(validerString(verdi, objectPath, locale))
+                }
+
+                is Søknadsfelt<*> -> {
+                    feil.addAll(validerSøknadsfelt(verdi, objectPath))
+                }
+
+                is Map<*, *> -> {
+                    verdi.forEach { (key, value) ->
+                        feil.addAll(validerVerdiRekursivt(value, "$objectPath.$key", locale))
+                    }
+                }
+
+                is Collection<*> -> {
+                    verdi.forEachIndexed { index, element ->
+                        feil.addAll(validerVerdiRekursivt(element, "$objectPath[$index]", locale))
+                    }
+                }
+
+                else -> {
+                    // Refleksjon: traverser feltene i ukjente objekter (f.eks. Arbeidsperiode, Pensjonsperiode, etc.)
+                    verdi::class.memberProperties.forEach { prop ->
+                        try {
+                            val feltVerdi = prop.getter.call(verdi)
+                            if (feltVerdi != null) {
+                                feil.addAll(validerVerdiRekursivt(feltVerdi, "$objectPath.${prop.name}", locale))
+                            }
+                        } catch (_: Exception) {
+                            // Ignorer felt som ikke kan leses
+                        }
+                    }
+                }
+            }
+
+            return feil
+        }
+
+        private fun <T> validerSøknadsfelt(
+            søknadsfelt: Søknadsfelt<T>,
+            objectPath: String,
+        ): List<Valideringsfeil> {
+            val feil = mutableListOf<Valideringsfeil>()
+
+            søknadsfelt.label.forEach { (locale, label) ->
+                if (label.length > MAKS_LENGDE) {
+                    feil.add(
+                        Valideringsfeil(
+                            objectPath = "$objectPath.label",
+                            locale = locale,
+                            feilmelding = "Label overskrider maksimal lengde på $MAKS_LENGDE tegn (faktisk: ${label.length})",
+                        ),
+                    )
+                }
+
+                if (UGYLDIGE_TEGN_REGEX.containsMatchIn(label)) {
+                    feil.add(
+                        Valideringsfeil(
+                            objectPath = "$objectPath.label",
+                            locale = locale,
+                            feilmelding = "Label inneholder ugyldige tegn: $label",
+                        ),
+                    )
+                }
+            }
+
+            // Valider verdi - traverser rekursivt for å finne alle String-verdier
+            søknadsfelt.verdi.forEach { (locale, verdi) ->
+                feil.addAll(validerVerdiRekursivt(verdi, "$objectPath.verdi", locale))
+            }
+
+            return feil
+        }
+    }
+}

--- a/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/KontantstøtteSøknadValidatorTest.kt
+++ b/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/KontantstøtteSøknadValidatorTest.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.kontrakter.ks.søknad
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.assertNotNull
+
+/**
+ * Test som sikrer at alle støttede versjoner av KontantstøtteSøknad har en tilhørende validator.
+ * Dette tester eksistensen av validator-klasser for alle versjoner som er definert i
+ * StøttetVersjonertKontantstøtteSøknad.
+ */
+class KontantstøtteSøknadValidatorTest {
+    @Test
+    fun `alle støttede versjoner over 6 av KontantstøtteSøknad skal ha en egen validator klasse med funksjon som valider kontrakten`() {
+        val klasserSomArverStøttetVersjonertKontantstøtteSøknad = StøttetVersjonertKontantstøtteSøknad::class.sealedSubclasses
+
+        val versjonerSomSkalHaValidatorKlasse =
+            klasserSomArverStøttetVersjonertKontantstøtteSøknad
+                .mapNotNull {
+                    it.simpleName?.substringAfterLast("V")?.toInt()
+                }.filter { it >= 6 }
+
+        versjonerSomSkalHaValidatorKlasse.forEach { versjon ->
+            assertDoesNotThrow("V$versjon validator skal eksistere") {
+                val validatorClass = Class.forName("no.nav.familie.kontrakter.ks.søknad.v$versjon.KontantstøtteSøknadV${versjon}Validator")
+                assertNotNull(validatorClass, "KontantstøtteSøknad versjon $versjon mangler en KontantstøtteSøknadV${versjon}Validator")
+
+                val companionClass = validatorClass.getDeclaredField("Companion").type
+                val validerMethod =
+                    companionClass.getDeclaredMethod(
+                        "valider",
+                        Class.forName("no.nav.familie.kontrakter.ks.søknad.v$versjon.KontantstøtteSøknad"),
+                    )
+
+                assertNotNull(validerMethod, "KontantstøtteSøknadV${versjon}Validator mangler en companion metode med navn valider")
+            }
+        }
+    }
+}

--- a/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/v6/KontantstøtteSøknadV6ValidatorTest.kt
+++ b/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/v6/KontantstøtteSøknadV6ValidatorTest.kt
@@ -1,0 +1,910 @@
+package no.nav.familie.kontrakter.ks.søknad.v6
+
+import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
+import no.nav.familie.kontrakter.ks.søknad.v1.Dokumentasjonsbehov
+import no.nav.familie.kontrakter.ks.søknad.v1.KontantstøttePeriode
+import no.nav.familie.kontrakter.ks.søknad.v1.Pensjonsperiode
+import no.nav.familie.kontrakter.ks.søknad.v1.RegistrertBostedType
+import no.nav.familie.kontrakter.ks.søknad.v1.SIVILSTANDTYPE
+import no.nav.familie.kontrakter.ks.søknad.v1.SøknadAdresse
+import no.nav.familie.kontrakter.ks.søknad.v1.Søknaddokumentasjon
+import no.nav.familie.kontrakter.ks.søknad.v1.Søknadsvedlegg
+import no.nav.familie.kontrakter.ks.søknad.v1.TekstPåSpråkMap
+import no.nav.familie.kontrakter.ks.søknad.v1.Utbetalingsperiode
+import no.nav.familie.kontrakter.ks.søknad.v2.Omsorgsperson
+import no.nav.familie.kontrakter.ks.søknad.v4.AndreForelder
+import no.nav.familie.kontrakter.ks.søknad.v4.Arbeidsperiode
+import no.nav.familie.kontrakter.ks.søknad.v4.Søker
+import no.nav.familie.kontrakter.ks.søknad.v4.Utenlandsperiode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KontantstøtteSøknadV6ValidatorTest {
+    private val gyldigLabel = mapOf("nb" to "Gyldig label", "nn" to "Gyldig label")
+    private val gyldigVerdi = mapOf("nb" to "Gyldig verdi", "nn" to "Gyldig verdi")
+    private val langStreng = "a".repeat(201)
+
+    @Test
+    fun `valider skal returnere tom liste når alle felter er gyldige`() {
+        val søknad = lagGyldigSøknad()
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty(), "Forventet ingen valideringsfeil for gyldig søknad")
+    }
+
+    @Test
+    fun `valider skal returnere feil når søker ident label er for lang`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        ident =
+                            Søknadsfelt(
+                                label = mapOf("nb" to langStreng),
+                                verdi = gyldigVerdi,
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.ident.label", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+        assertTrue(feil[0].feilmelding.contains("Label overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når søker navn verdi er for lang`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        navn =
+                            Søknadsfelt(
+                                label = gyldigLabel,
+                                verdi = mapOf("nb" to langStreng),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.navn.verdi", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når barn ident label er for lang`() {
+        val barn =
+            lagGyldigBarn().copy(
+                ident =
+                    Søknadsfelt(
+                        label = mapOf("nn" to langStreng),
+                        verdi = gyldigVerdi,
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].ident.label", feil[0].objectPath)
+        assertEquals("nn", feil[0].locale)
+    }
+
+    @Test
+    fun `valider skal returnere feil når toppnivå Søknadsfelt label er for lang`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                erNoenAvBarnaFosterbarn =
+                    Søknadsfelt(
+                        label = mapOf("nb" to langStreng),
+                        verdi = gyldigVerdi,
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("erNoenAvBarnaFosterbarn.label", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+    }
+
+    @Test
+    fun `valider skal returnere flere feil når flere felter er ugyldige`() {
+        val barn =
+            lagGyldigBarn().copy(
+                ident =
+                    Søknadsfelt(
+                        label = mapOf("nb" to langStreng, "nn" to langStreng),
+                        verdi = gyldigVerdi,
+                    ),
+                navn =
+                    Søknadsfelt(
+                        label = gyldigLabel,
+                        verdi = mapOf("nb" to langStreng),
+                    ),
+            )
+
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        navn =
+                            Søknadsfelt(
+                                label = mapOf("nb" to langStreng),
+                                verdi = gyldigVerdi,
+                            ),
+                    ),
+                barn = listOf(barn),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(4, feil.size)
+        assertTrue(feil.any { it.objectPath == "søker.navn.label" && it.locale == "nb" })
+        assertTrue(feil.any { it.objectPath == "barn[0].ident.label" && it.locale == "nb" })
+        assertTrue(feil.any { it.objectPath == "barn[0].ident.label" && it.locale == "nn" })
+        assertTrue(feil.any { it.objectPath == "barn[0].navn.verdi" && it.locale == "nb" })
+    }
+
+    @Test
+    fun `valider skal returnere feil når label er nøyaktig 201 tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        ident =
+                            Søknadsfelt(
+                                label = mapOf("nb" to "a".repeat(201)),
+                                verdi = gyldigVerdi,
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertTrue(feil[0].feilmelding.contains("201"))
+    }
+
+    @Test
+    fun `valider skal ikke returnere feil når label er nøyaktig 200 tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        ident =
+                            Søknadsfelt(
+                                label = mapOf("nb" to "a".repeat(200)),
+                                verdi = gyldigVerdi,
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty(), "Label med nøyaktig 200 tegn skal være gyldig")
+    }
+
+    @Test
+    fun `valider skal returnere feil når label inneholder mindre enn tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        ident =
+                            Søknadsfelt(
+                                label = mapOf("nb" to "Test < verdi"),
+                                verdi = gyldigVerdi,
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.ident.label", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når label inneholder større enn tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        navn =
+                            Søknadsfelt(
+                                label = mapOf("nb" to "Test > verdi"),
+                                verdi = gyldigVerdi,
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.navn.label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når label inneholder anførselstegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        statsborgerskap =
+                            Søknadsfelt(
+                                label = mapOf("nb" to "Test \"verdi\""),
+                                verdi = mapOf("nb" to listOf("NOR")),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.statsborgerskap.label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når verdi inneholder ugyldige tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        navn =
+                            Søknadsfelt(
+                                label = gyldigLabel,
+                                verdi = mapOf("nb" to "Test < verdi"),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("søker.navn.verdi", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+        assertTrue(feil[0].feilmelding.contains("Verdi"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når barn verdi inneholder anførselstegn`() {
+        val barn =
+            lagGyldigBarn().copy(
+                navn =
+                    Søknadsfelt(
+                        label = gyldigLabel,
+                        verdi = mapOf("nb" to "Test \"verdi\""),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].navn.verdi", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    // --- Tester for teksterTilPdf ---
+
+    @Test
+    fun `valider skal returnere feil når teksterTilPdf har for lang streng`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                teksterTilPdf =
+                    mapOf(
+                        "tekst1" to TekstPåSpråkMap(mapOf("nb" to langStreng)),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("teksterTilPdf.tekst1", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når teksterTilPdf inneholder ugyldige tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                teksterTilPdf =
+                    mapOf(
+                        "tekst1" to TekstPåSpråkMap(mapOf("nb" to "Test<script>alert</script>")),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("teksterTilPdf.tekst1", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil for flere locales i teksterTilPdf`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                teksterTilPdf =
+                    mapOf(
+                        "tekst1" to TekstPåSpråkMap(mapOf("nb" to langStreng, "nn" to langStreng)),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(2, feil.size)
+        assertTrue(feil.any { it.locale == "nb" })
+        assertTrue(feil.any { it.locale == "nn" })
+    }
+
+    // --- Tester for dokumentasjon ---
+
+    @Test
+    fun `valider skal returnere feil når dokumentasjon språktittel er for lang`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg = emptyList(),
+                            dokumentasjonSpråkTittel = TekstPåSpråkMap(mapOf("nb" to langStreng)),
+                        ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].dokumentasjonSpråkTittel", feil[0].objectPath)
+        assertEquals("nb", feil[0].locale)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når dokumentasjon språktittel inneholder ugyldige tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg = emptyList(),
+                            dokumentasjonSpråkTittel = TekstPåSpråkMap(mapOf("nb" to "Tittel med <html>")),
+                        ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].dokumentasjonSpråkTittel", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når vedlegg navn er for langt`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg =
+                                listOf(
+                                    Søknadsvedlegg(
+                                        dokumentId = "dok-123",
+                                        navn = langStreng,
+                                        tittel = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                                    ),
+                                ),
+                            dokumentasjonSpråkTittel = TekstPåSpråkMap(mapOf("nb" to "Gyldig tittel")),
+                        ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].opplastedeVedlegg[0].navn", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når vedlegg dokumentId er for lang`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                dokumentasjon =
+                    listOf(
+                        Søknaddokumentasjon(
+                            dokumentasjonsbehov = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                            harSendtInn = false,
+                            opplastedeVedlegg =
+                                listOf(
+                                    Søknadsvedlegg(
+                                        dokumentId = langStreng,
+                                        navn = "gyldig-fil.pdf",
+                                        tittel = Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+                                    ),
+                                ),
+                            dokumentasjonSpråkTittel = TekstPåSpråkMap(mapOf("nb" to "Gyldig tittel")),
+                        ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("dokumentasjon[0].opplastedeVedlegg[0].dokumentId", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    // --- Tester for andreForelder ---
+
+    @Test
+    fun `valider skal returnere feil når andreForelder har ugyldig felt`() {
+        val barn =
+            lagGyldigBarn().copy(
+                andreForelder =
+                    lagGyldigAndreForelder().copy(
+                        navn = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].andreForelder.navn.verdi", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når andreForelder label inneholder ugyldige tegn`() {
+        val barn =
+            lagGyldigBarn().copy(
+                andreForelder =
+                    lagGyldigAndreForelder().copy(
+                        kanIkkeGiOpplysninger =
+                            Søknadsfelt(
+                                label = mapOf("nb" to "Test<>verdi"),
+                                verdi = mapOf("nb" to "NEI"),
+                            ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].andreForelder.kanIkkeGiOpplysninger.label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når andreForelder liste-element har ugyldig felt`() {
+        val barn =
+            lagGyldigBarn().copy(
+                andreForelder =
+                    lagGyldigAndreForelder().copy(
+                        arbeidsperioderUtland =
+                            listOf(
+                                Søknadsfelt(
+                                    label = mapOf("nb" to langStreng),
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                lagGyldigArbeidsperiode(),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].andreForelder.arbeidsperioderUtland[0].label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Label overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal ikke returnere feil når andreForelder er null`() {
+        val barn = lagGyldigBarn().copy(andreForelder = null)
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty())
+    }
+
+    // --- Tester for omsorgsperson ---
+
+    @Test
+    fun `valider skal returnere feil når omsorgsperson har ugyldig felt`() {
+        val barn =
+            lagGyldigBarn().copy(
+                omsorgsperson =
+                    lagGyldigOmsorgsperson().copy(
+                        navn = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].omsorgsperson.navn.verdi", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    @Test
+    fun `valider skal returnere feil når omsorgsperson label inneholder ugyldige tegn`() {
+        val barn =
+            lagGyldigBarn().copy(
+                omsorgsperson =
+                    lagGyldigOmsorgsperson().copy(
+                        slektsforhold =
+                            Søknadsfelt(
+                                label = mapOf("nb" to "Test<>verdi"),
+                                verdi = mapOf("nb" to "FORELDER"),
+                            ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].omsorgsperson.slektsforhold.label", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("ugyldige tegn"))
+    }
+
+    @Test
+    fun `valider skal ikke returnere feil når omsorgsperson er null`() {
+        val barn = lagGyldigBarn().copy(omsorgsperson = null)
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty())
+    }
+
+    // --- Tester for rekursiv validering ---
+
+    @Test
+    fun `valider skal finne ugyldig label inne i Utbetalingsperiode via refleksjon`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        andreUtbetalingsperioder =
+                            listOf(
+                                Søknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                Utbetalingsperiode(
+                                                    fårUtbetalingNå =
+                                                        Søknadsfelt(
+                                                            label = mapOf("nb" to langStreng),
+                                                            verdi = mapOf("nb" to "JA"),
+                                                        ),
+                                                    utbetalingLand = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige")),
+                                                    utbetalingFraDato =
+                                                        Søknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi = mapOf("nb" to "2020-01-01"),
+                                                        ),
+                                                    utbetalingTilDato =
+                                                        Søknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi = mapOf("nb" to "2021-01-01"),
+                                                        ),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Forventet valideringsfeil for ugyldig label i Utbetalingsperiode")
+        assertTrue(feil.any { it.feilmelding.contains("Label overskrider maksimal lengde") })
+    }
+
+    @Test
+    fun `valider skal finne ugyldig verdi inne i Arbeidsperiode via refleksjon`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        arbeidsperioderUtland =
+                            listOf(
+                                Søknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                lagGyldigArbeidsperiode().copy(
+                                                    arbeidsgiver =
+                                                        Søknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi = mapOf("nb" to langStreng),
+                                                        ),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Forventet valideringsfeil for ugyldig verdi i Arbeidsperiode")
+        assertTrue(feil.any { it.feilmelding.contains("Verdi overskrider maksimal lengde") })
+    }
+
+    @Test
+    fun `valider skal finne ugyldige tegn inne i Pensjonsperiode via refleksjon`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        pensjonsperioderUtland =
+                            listOf(
+                                Søknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                lagGyldigPensjonsperiode().copy(
+                                                    pensjonsland =
+                                                        Søknadsfelt(
+                                                            label = gyldigLabel,
+                                                            verdi = mapOf("nb" to "Sverige<script>"),
+                                                        ),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Forventet valideringsfeil for ugyldige tegn i Pensjonsperiode")
+        assertTrue(feil.any { it.feilmelding.contains("ugyldige tegn") })
+    }
+
+    @Test
+    fun `valider skal finne ugyldig felt inne i KontantstøttePeriode via refleksjon`() {
+        val barn =
+            lagGyldigBarn().copy(
+                eøsKontantstøttePerioder =
+                    listOf(
+                        Søknadsfelt(
+                            label = gyldigLabel,
+                            verdi =
+                                mapOf(
+                                    "nb" to
+                                        lagGyldigKontantstøttePeriode().copy(
+                                            månedligBeløp = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                                        ),
+                                ),
+                        ),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Forventet valideringsfeil for ugyldig felt i KontantstøttePeriode")
+        assertTrue(feil.any { it.feilmelding.contains("Verdi overskrider maksimal lengde") })
+    }
+
+    // --- Tester for barn teksterTilPdf ---
+
+    @Test
+    fun `valider skal returnere feil når barn teksterTilPdf har for lang streng`() {
+        val barn =
+            lagGyldigBarn().copy(
+                teksterTilPdf =
+                    mapOf(
+                        "barnTekst" to TekstPåSpråkMap(mapOf("nb" to langStreng)),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertEquals(1, feil.size)
+        assertEquals("barn[0].teksterTilPdf.barnTekst", feil[0].objectPath)
+        assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
+    }
+
+    private fun lagGyldigSøknad() =
+        KontantstøtteSøknad(
+            kontraktVersjon = 6,
+            søker = lagGyldigSøker(),
+            barn = listOf(lagGyldigBarn()),
+            antallEøsSteg = 0,
+            dokumentasjon = emptyList(),
+            teksterTilPdf = emptyMap(),
+            originalSpråk = "nb",
+            finnesPersonMedAdressebeskyttelse = false,
+            erNoenAvBarnaFosterbarn = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            søktAsylForBarn = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            oppholderBarnSegIInstitusjon = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            barnOppholdtSegTolvMndSammenhengendeINorge = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            erBarnAdoptert = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            mottarKontantstøtteForBarnFraAnnetEøsland = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            harEllerTildeltBarnehageplass = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            erAvdødPartnerForelder = null,
+        )
+
+    private fun lagGyldigSøker() =
+        Søker(
+            harEøsSteg = false,
+            ident = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            navn = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            statsborgerskap = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to listOf("NOR"))),
+            adresse =
+                Søknadsfelt(
+                    label = gyldigLabel,
+                    verdi =
+                        mapOf(
+                            "nb" to
+                                SøknadAdresse(
+                                    adressenavn = "Testveien 1",
+                                    postnummer = "0001",
+                                    husbokstav = null,
+                                    bruksenhetsnummer = null,
+                                    husnummer = "1",
+                                    poststed = "Oslo",
+                                ),
+                        ),
+                ),
+            adressebeskyttelse = false,
+            sivilstand = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to SIVILSTANDTYPE.GIFT)),
+            borPåRegistrertAdresse = null,
+            værtINorgeITolvMåneder = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            planleggerÅBoINorgeTolvMnd = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            yrkesaktivFemÅr = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            erAsylsøker = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            utenlandsoppholdUtenArbeid = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            utenlandsperioder = emptyList(),
+            arbeidIUtlandet = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            arbeidsperioderUtland = emptyList(),
+            mottarUtenlandspensjon = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            pensjonsperioderUtland = emptyList(),
+            arbeidINorge = null,
+            arbeidsperioderNorge = emptyList(),
+            pensjonNorge = null,
+            pensjonsperioderNorge = emptyList(),
+            andreUtbetalingsperioder = emptyList(),
+            idNummer = emptyList(),
+            andreUtbetalinger = null,
+            adresseISøkeperiode = null,
+        )
+
+    private fun lagGyldigBarn() =
+        Barn(
+            harEøsSteg = false,
+            ident = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            navn = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            registrertBostedType =
+                Søknadsfelt(
+                    label = gyldigLabel,
+                    verdi = mapOf("nb" to RegistrertBostedType.REGISTRERT_SOKERS_ADRESSE),
+                ),
+            alder = null,
+            teksterTilPdf = emptyMap(),
+            erFosterbarn = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            oppholderSegIInstitusjon = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            erAdoptert = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            erAsylsøker = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            boddMindreEnn12MndINorge = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            kontantstøtteFraAnnetEøsland = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            harBarnehageplass = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            andreForelderErDød = null,
+            utbetaltForeldrepengerEllerEngangsstønad = null,
+            mottarEllerMottokEøsKontantstøtte = null,
+            pågåendeSøknadFraAnnetEøsLand = null,
+            pågåendeSøknadHvilketLand = null,
+            planleggerÅBoINorge12Mnd = null,
+            borFastMedSøker = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+            foreldreBorSammen = null,
+            søkerDeltKontantstøtte = null,
+            andreForelder = null,
+            søkersSlektsforhold = null,
+            søkersSlektsforholdSpesifisering = null,
+            borMedAndreForelder = null,
+            borMedOmsorgsperson = null,
+            adresse = null,
+            omsorgsperson = null,
+        )
+
+    private fun lagGyldigAndreForelder() =
+        AndreForelder(
+            kanIkkeGiOpplysninger = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            navn = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Ola Nordmann")),
+            fnr = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "12345678910")),
+            fødselsdato = null,
+            yrkesaktivFemÅr = null,
+            arbeidUtlandet = null,
+            utenlandsoppholdUtenArbeid = null,
+            pensjonUtland = null,
+            adresse = null,
+            arbeidNorge = null,
+            pensjonNorge = null,
+            andreUtbetalinger = null,
+            pågåendeSøknadFraAnnetEøsLand = null,
+            pågåendeSøknadHvilketLand = null,
+            kontantstøtteFraEøs = null,
+        )
+
+    private fun lagGyldigOmsorgsperson() =
+        Omsorgsperson(
+            navn = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Kari Nordmann")),
+            slektsforhold = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "FORELDER")),
+            slektsforholdSpesifisering = null,
+            idNummer = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "12345678910")),
+            adresse = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Testveien 1")),
+            arbeidUtland = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            arbeidNorge = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "JA")),
+            pensjonUtland = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            pensjonNorge = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            andreUtbetalinger = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            pågåendeSøknadFraAnnetEøsLand = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+            pågåendeSøknadHvilketLand = null,
+            kontantstøtteFraEøs = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "NEI")),
+        )
+
+    private fun lagGyldigArbeidsperiode() =
+        Arbeidsperiode(
+            arbeidsperiodeAvsluttet = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "JA")),
+            arbeidsperiodeland = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige")),
+            arbeidsgiver = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "IKEA")),
+            fraDatoArbeidsperiode = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
+            tilDatoArbeidsperiode = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2021-01-01")),
+            adresse = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Testveien 1")),
+        )
+
+    private fun lagGyldigPensjonsperiode() =
+        Pensjonsperiode(
+            mottarPensjonNå = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "JA")),
+            pensjonsland = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Sverige")),
+            pensjonFra = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
+            pensjonTil = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2021-01-01")),
+        )
+
+    private fun lagGyldigKontantstøttePeriode() =
+        KontantstøttePeriode(
+            mottarEøsKontantstøtteNå = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "JA")),
+            kontantstøtteLand = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "Danmark")),
+            fraDatoKontantstøttePeriode = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2020-01-01")),
+            tilDatoKontantstøttePeriode = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "2021-01-01")),
+            månedligBeløp = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to "1000")),
+        )
+}


### PR DESCRIPTION
[NAV-23039
](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-23039)
Tilsvarende validering som i Barnetrygd

Lagt til en klasse for å validere inputverdier i Barnetrygd-søknaden. Den traveserer kontrakten og tar vare på alle inputvalideringsfeilene. Da vil man få en liste med valideringsfeil, som kan brukes fra familie-baks-soknad-api. I første gang til å logge.

Validering av lengde på alle strengfelt i kontrakt
Valider ukjente tegn i label
Valider verdi for ugyldige tegn
Test for å sjekke at nye kontrakter får en validator

Tilsvarende PRer for Barnetrygd
https://github.com/navikt/familie-kontrakter/pull/1106 (merget)
https://github.com/navikt/familie-kontrakter/pull/1135