### PR TITLE
Legg til avslutt sak request som skal benyttes i både integrasjoner og konsumenter

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/dokarkiv/AvsluttSakRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/dokarkiv/AvsluttSakRequest.kt
@@ -1,0 +1,16 @@
+package no.nav.familie.kontrakter.felles.dokarkiv
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import java.time.LocalDateTime
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AvsluttSakRequest(
+    val tema: String,
+    val fagsakId: String,
+    val fagsaksystem: String,
+    val bruker: DokarkivBruker,
+    val opprettetDato: LocalDateTime,
+    val administrativEnhet: String,
+    val avsluttetDato: LocalDateTime? = null,
+    val sakAnsvarlig: String? = null,
+)


### PR DESCRIPTION
Legg til avslutt sak request som skal benyttes i både integrasjoner og konsumentene for å avslutte en sak hos dokarkiv.

Se https://dokarkiv.dev.intern.nav.no/swagger-ui/index.html#/journalpostapi%20-%20sak/avsluttSak.
