### PR TITLE
Legg til gjenåpne sak request for bruk i familie-integrasjoner og konsumentene

### DIFF
--- a/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/dokarkiv/GjenåpneSakRequest.kt
+++ b/felles/src/main/kotlin/no/nav/familie/kontrakter/felles/dokarkiv/GjenåpneSakRequest.kt
@@ -1,0 +1,11 @@
+package no.nav.familie.kontrakter.felles.dokarkiv
+
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.Tema
+
+data class GjenåpneSakRequest(
+    val tema: Tema,
+    val fagsakId: String,
+    val fagsaksystem: Fagsystem,
+    val bruker: DokarkivBruker,
+)


### PR DESCRIPTION
Favrokort : [NAV-29110](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29110)

Vi i Team BAKS jobber med å opprette funksjonalitet for å låse ned og åpne fagsak i joark.
Legger derfor til til gjenåpne sak request som skal benyttes i både integrasjoner og konsumentene for å gjenåpne en sak hos dokarkiv.

Se https://dokarkiv.dev.intern.nav.no/swagger-ui/index.html#/journalpostapi%20-%20sak/gjenaapneSak