### PR TITLE
Tillat at adresser er 500 tegn

### DIFF
--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/Valideringsfeil.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/Valideringsfeil.kt
@@ -16,4 +16,5 @@ data class Valideringsfeil(
 )
 
 const val MAKS_LENGDE = 200
+const val MAKS_LENGDE_ADRESSE = 500
 val UGYLDIGE_TEGN_REGEX = Regex("[<>\"]")

--- a/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
+++ b/barnetrygd/src/main/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10Validator.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.kontrakter.ba.søknad.v10
 
 import no.nav.familie.kontrakter.ba.søknad.MAKS_LENGDE
+import no.nav.familie.kontrakter.ba.søknad.MAKS_LENGDE_ADRESSE
 import no.nav.familie.kontrakter.ba.søknad.UGYLDIGE_TEGN_REGEX
 import no.nav.familie.kontrakter.ba.søknad.Valideringsfeil
 import no.nav.familie.kontrakter.ba.søknad.v4.Locale
@@ -295,13 +296,15 @@ class BarnetrygdSøknadV10Validator {
             locale: Locale,
         ): List<Valideringsfeil> {
             val feil = mutableListOf<Valideringsfeil>()
+            val erAdresseFelt = objectPath.contains(".adresse.")
+            val maksLengde = if (erAdresseFelt) MAKS_LENGDE_ADRESSE else MAKS_LENGDE
 
-            if (verdi.length > MAKS_LENGDE) {
+            if (verdi.length > maksLengde) {
                 feil.add(
                     Valideringsfeil(
                         objectPath = objectPath,
                         locale = locale,
-                        feilmelding = "Verdi overskrider maksimal lengde på $MAKS_LENGDE tegn (faktisk: ${verdi.length})",
+                        feilmelding = "Verdi overskrider maksimal lengde på $maksLengde tegn (faktisk: ${verdi.length})",
                     ),
                 )
             }

--- a/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10ValidatorTest.kt
+++ b/barnetrygd/src/test/kotlin/no/nav/familie/kontrakter/ba/søknad/v10/BarnetrygdSøknadV10ValidatorTest.kt
@@ -1123,6 +1123,57 @@ class BarnetrygdSøknadV10ValidatorTest {
         assertTrue(feil.isEmpty(), "Forventet ingen feil for gyldige verdier i Arbeidsperiode")
     }
 
+    @Test
+    fun `valider skal tillate adresse opptil 500 tegn for omsorgsperson`() {
+        val adresse500Tegn = "a".repeat(500)
+        val barn =
+            lagGyldigBarn().copy(
+                omsorgsperson =
+                    lagGyldigOmsorgsperson().copy(
+                        adresse = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to adresse500Tegn)),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty(), "Forventet ingen feil ved adresse opp mot 500 tegn")
+    }
+
+    @Test
+    fun `valider skal returnere feil når adresse overskrider 500 tegn`() {
+        val adresse501Tegn = "a".repeat(501)
+        val barn =
+            lagGyldigBarn().copy(
+                omsorgsperson =
+                    lagGyldigOmsorgsperson().copy(
+                        adresse = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to adresse501Tegn)),
+                    ),
+            )
+        val søknad = lagGyldigSøknad().copy(barn = listOf(barn))
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Adresse på 501 tegn skal gi valideringsfeil")
+        assertTrue(feil.any { it.objectPath.contains(".adresse.") && it.feilmelding.contains("Verdi overskrider maksimal lengde på 500") })
+    }
+
+    @Test
+    fun `valider skal fortsatt begrense ikke-adresse felter til 200 tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        navn = FellesSøknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to langStreng)),
+                    ),
+            )
+
+        val feil = BarnetrygdSøknadV10Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty())
+        assertTrue(feil.any { it.feilmelding.contains("Verdi overskrider maksimal lengde på 200") })
+    }
+
     private fun lagGyldigSøknad() =
         BarnetrygdSøknad(
             kontraktVersjon = 10,

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/Valideringsfeil.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/Valideringsfeil.kt
@@ -16,4 +16,5 @@ data class Valideringsfeil(
 )
 
 const val MAKS_LENGDE = 200
+const val MAKS_LENGDE_ADRESSE = 500
 val UGYLDIGE_TEGN_REGEX = Regex("[<>\"]")

--- a/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v6/KontantstøtteSøknadV6Validator.kt
+++ b/kontantstotte/src/main/kotlin/no/nav/familie/kontrakter/ks/søknad/v6/KontantstøtteSøknadV6Validator.kt
@@ -2,6 +2,7 @@ package no.nav.familie.kontrakter.ks.søknad.v6
 
 import no.nav.familie.kontrakter.felles.søknad.Søknadsfelt
 import no.nav.familie.kontrakter.ks.søknad.MAKS_LENGDE
+import no.nav.familie.kontrakter.ks.søknad.MAKS_LENGDE_ADRESSE
 import no.nav.familie.kontrakter.ks.søknad.UGYLDIGE_TEGN_REGEX
 import no.nav.familie.kontrakter.ks.søknad.Valideringsfeil
 import no.nav.familie.kontrakter.ks.søknad.v1.Locale
@@ -311,13 +312,15 @@ class KontantstøtteSøknadV6Validator {
             locale: Locale,
         ): List<Valideringsfeil> {
             val feil = mutableListOf<Valideringsfeil>()
+            val erAdresseFelt = objectPath.contains(".adresse.")
+            val maksLengde = if (erAdresseFelt) MAKS_LENGDE_ADRESSE else MAKS_LENGDE
 
-            if (verdi.length > MAKS_LENGDE) {
+            if (verdi.length > maksLengde) {
                 feil.add(
                     Valideringsfeil(
                         objectPath = objectPath,
                         locale = locale,
-                        feilmelding = "Verdi overskrider maksimal lengde på $MAKS_LENGDE tegn (faktisk: ${verdi.length})",
+                        feilmelding = "Verdi overskrider maksimal lengde på $maksLengde tegn (faktisk: ${verdi.length})",
                     ),
                 )
             }

--- a/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/v6/KontantstøtteSøknadV6ValidatorTest.kt
+++ b/kontantstotte/src/test/kotlin/no/nav/familie/kontrakter/ks/søknad/v6/KontantstøtteSøknadV6ValidatorTest.kt
@@ -743,6 +743,91 @@ class KontantstøtteSøknadV6ValidatorTest {
         assertTrue(feil[0].feilmelding.contains("Verdi overskrider maksimal lengde"))
     }
 
+    @Test
+    fun `valider skal tillate adresse opptil 500 tegn i utenlandsperioder`() {
+        val adresse500Tegn = "a".repeat(500)
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        utenlandsperioder =
+                            listOf(
+                                Søknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                Utenlandsperiode(
+                                                    utenlandsoppholdÅrsak = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+                                                    oppholdsland = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+                                                    oppholdslandFraDato = null,
+                                                    oppholdslandTilDato = null,
+                                                    adresse = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to adresse500Tegn)),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isEmpty(), "Forventet ingen feil ved adresse opp mot 500 tegn")
+    }
+
+    @Test
+    fun `valider skal returnere feil når adresse i utenlandsperioder overskrider 500 tegn`() {
+        val adresse501Tegn = "a".repeat(501)
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        utenlandsperioder =
+                            listOf(
+                                Søknadsfelt(
+                                    label = gyldigLabel,
+                                    verdi =
+                                        mapOf(
+                                            "nb" to
+                                                Utenlandsperiode(
+                                                    utenlandsoppholdÅrsak = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+                                                    oppholdsland = Søknadsfelt(label = gyldigLabel, verdi = gyldigVerdi),
+                                                    oppholdslandFraDato = null,
+                                                    oppholdslandTilDato = null,
+                                                    adresse = Søknadsfelt(label = gyldigLabel, verdi = mapOf("nb" to adresse501Tegn)),
+                                                ),
+                                        ),
+                                ),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty(), "Adresse på 501 tegn skal gi valideringsfeil")
+        assertTrue(feil.any { it.objectPath.contains(".adresse.") && it.feilmelding.contains("Verdi overskrider maksimal lengde på 500") })
+    }
+
+    @Test
+    fun `valider skal fortsatt begrense ikke-adresse felter til 200 tegn`() {
+        val søknad =
+            lagGyldigSøknad().copy(
+                søker =
+                    lagGyldigSøker().copy(
+                        navn =
+                            Søknadsfelt(
+                                label = gyldigLabel,
+                                verdi = mapOf("nb" to langStreng),
+                            ),
+                    ),
+            )
+
+        val feil = KontantstøtteSøknadV6Validator.valider(søknad)
+
+        assertTrue(feil.isNotEmpty())
+        assertTrue(feil.any { it.feilmelding.contains("Verdi overskrider maksimal lengde på 200") })
+    }
+
     private fun lagGyldigSøknad() =
         KontantstøtteSøknad(
             kontraktVersjon = 6,


### PR DESCRIPTION
Favrokort: Nav-29116

Vi tillater at adresser er opptil 500 tegn da vi har sett instanser av at valideringen har stanset søknader med adresse lengre enn 200 tegn (nåværende grense)